### PR TITLE
refactor: move data input to the end and as optional

### DIFF
--- a/demos/default.html
+++ b/demos/default.html
@@ -57,7 +57,7 @@
           },
         },
       };
-      const hermes = new Hermes.default('#hermes', data, dimensions, config);
+      const hermes = new Hermes.default('#hermes', dimensions, config, data);
     </script>
   </body>
 </html>

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -1261,7 +1261,7 @@ var tester = /*#__PURE__*/Object.freeze({
 
 const customDeepmerge = deepmergeCustom({ mergeArrays: false });
 class Hermes {
-    constructor(target, data, dimensions, config = {}) {
+    constructor(target, dimensions, config = {}, data = {}) {
         this.size = { h: 0, w: 0 };
         this.ix = clone(IX);
         this.filters = {};

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -1257,7 +1257,7 @@ var tester = /*#__PURE__*/Object.freeze({
 
 const customDeepmerge = deepmergeCustom({ mergeArrays: false });
 class Hermes {
-    constructor(target, data, dimensions, config = {}) {
+    constructor(target, dimensions, config = {}, data = {}) {
         this.size = { h: 0, w: 0 };
         this.ix = clone(IX);
         this.filters = {};

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -1260,7 +1260,7 @@ var Hermes = (function (exports) {
 
   const customDeepmerge = deepmergeCustom({ mergeArrays: false });
   class Hermes {
-      constructor(target, data, dimensions, config = {}) {
+      constructor(target, dimensions, config = {}, data = {}) {
           this.size = { h: 0, w: 0 };
           this.ix = clone(IX);
           this.filters = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,9 +43,9 @@ class Hermes {
 
   constructor(
     target: HTMLElement | string,
-    data: t.Data,
     dimensions: t.Dimension[],
     config: t.RecursivePartial<t.Config> = {},
+    data: t.Data = {},
   ) {
     const element = getElement(target);
     if (!element) throw new HermesError('Target element selector did not match anything.');


### PR DESCRIPTION
The data may not always be available when the chart is getting instantiated. Alter the constructor to NOT require data upfront and make it optional.