### PR TITLE
[Issue-61] fix: link filter axis interactions

### DIFF
--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -80,23 +80,34 @@ const HERMES_CONFIG = {
                 lineWidth: 1,
                 strokeStyle: 'rgba(147, 147, 147, 1.0)',
             },
-            axisActve: { strokeStyle: 'rgba(255, 100, 0, 1.0)' },
-            axisHover: { strokeStyle: 'rgba(147, 147, 147, 1.0)' },
+            axisActve: {
+                lineWidth: 3,
+                strokeStyle: 'rgba(79, 180, 246, 1.0)',
+            },
+            axisHover: {
+                lineWidth: 3,
+                strokeStyle: 'rgba(99, 200, 255, 1.0)',
+            },
             filter: {
                 cornerRadius: 2,
-                fillStyle: 'rgba(0, 0, 0, 1.0)',
+                fillStyle: 'rgba(235, 100, 200, 1.0)',
                 strokeStyle: 'rgba(255, 255, 255, 1.0)',
                 width: 4,
             },
             filterActive: {
                 cornerRadius: 3,
-                fillStyle: 'rgba(255, 100, 0, 1.0)',
+                fillStyle: 'rgba(255, 120, 220, 1.0)',
+                width: 8,
+            },
+            filterAxisHover: {
+                cornerRadius: 2,
+                fillStyle: 'rgba(235, 100, 200, 1.0)',
                 width: 6,
             },
             filterHover: {
                 cornerRadius: 2,
-                fillStyle: 'rgba(200, 50, 0, 1.0)',
-                width: 4,
+                fillStyle: 'rgba(235, 100, 200, 1.0)',
+                width: 8,
             },
             label: {
                 fillStyle: 'rgba(0, 0, 0, 1.0)',
@@ -1606,7 +1617,9 @@ class Hermes {
                 _ixsa.type === ActionType.FilterMove ||
                 _ixsa.type === ActionType.FilterResizeAfter ||
                 _ixsa.type === ActionType.FilterResizeBefore) && _ixsa.dimIndex === i;
-            const isAxisFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionAxis && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
+            const isAxisFocused = ((_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionAxis ||
+                (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.Filter ||
+                (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.FilterResize) && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
             _s[i] = _s[i] || {};
             _s[i].label = {
                 ..._osd.label,
@@ -1632,10 +1645,13 @@ class Hermes {
                 const isFilterFocused = (((_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.Filter || (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.FilterResize) &&
                     (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i &&
                     (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.filterIndex) === j);
+                const isFilterAxisHover = isAxisActive || (isAxisFocused && !isFilterFocused);
+                const isFilterHover = isFilterFocused && _ixsa.filterIndex === undefined;
                 const isFilterActive = _ixsa.dimIndex === i && _ixsa.filterIndex === j;
                 return {
                     ..._osa.filter,
-                    ...(!isFilterActive && isFilterFocused && !isActive ? _osa.filterHover : {}),
+                    ...(isFilterAxisHover ? _osa.filterAxisHover : {}),
+                    ...(isFilterHover ? _osa.filterHover : {}),
                     ...(isFilterActive ? _osa.filterActive : {}),
                 };
             });

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -76,23 +76,34 @@ const HERMES_CONFIG = {
                 lineWidth: 1,
                 strokeStyle: 'rgba(147, 147, 147, 1.0)',
             },
-            axisActve: { strokeStyle: 'rgba(255, 100, 0, 1.0)' },
-            axisHover: { strokeStyle: 'rgba(147, 147, 147, 1.0)' },
+            axisActve: {
+                lineWidth: 3,
+                strokeStyle: 'rgba(79, 180, 246, 1.0)',
+            },
+            axisHover: {
+                lineWidth: 3,
+                strokeStyle: 'rgba(99, 200, 255, 1.0)',
+            },
             filter: {
                 cornerRadius: 2,
-                fillStyle: 'rgba(0, 0, 0, 1.0)',
+                fillStyle: 'rgba(235, 100, 200, 1.0)',
                 strokeStyle: 'rgba(255, 255, 255, 1.0)',
                 width: 4,
             },
             filterActive: {
                 cornerRadius: 3,
-                fillStyle: 'rgba(255, 100, 0, 1.0)',
+                fillStyle: 'rgba(255, 120, 220, 1.0)',
+                width: 8,
+            },
+            filterAxisHover: {
+                cornerRadius: 2,
+                fillStyle: 'rgba(235, 100, 200, 1.0)',
                 width: 6,
             },
             filterHover: {
                 cornerRadius: 2,
-                fillStyle: 'rgba(200, 50, 0, 1.0)',
-                width: 4,
+                fillStyle: 'rgba(235, 100, 200, 1.0)',
+                width: 8,
             },
             label: {
                 fillStyle: 'rgba(0, 0, 0, 1.0)',
@@ -1602,7 +1613,9 @@ class Hermes {
                 _ixsa.type === ActionType.FilterMove ||
                 _ixsa.type === ActionType.FilterResizeAfter ||
                 _ixsa.type === ActionType.FilterResizeBefore) && _ixsa.dimIndex === i;
-            const isAxisFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionAxis && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
+            const isAxisFocused = ((_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionAxis ||
+                (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.Filter ||
+                (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.FilterResize) && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
             _s[i] = _s[i] || {};
             _s[i].label = {
                 ..._osd.label,
@@ -1628,10 +1641,13 @@ class Hermes {
                 const isFilterFocused = (((_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.Filter || (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.FilterResize) &&
                     (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i &&
                     (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.filterIndex) === j);
+                const isFilterAxisHover = isAxisActive || (isAxisFocused && !isFilterFocused);
+                const isFilterHover = isFilterFocused && _ixsa.filterIndex === undefined;
                 const isFilterActive = _ixsa.dimIndex === i && _ixsa.filterIndex === j;
                 return {
                     ..._osa.filter,
-                    ...(!isFilterActive && isFilterFocused && !isActive ? _osa.filterHover : {}),
+                    ...(isFilterAxisHover ? _osa.filterAxisHover : {}),
+                    ...(isFilterHover ? _osa.filterHover : {}),
                     ...(isFilterActive ? _osa.filterActive : {}),
                 };
             });

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -79,23 +79,34 @@ var Hermes = (function (exports) {
                     lineWidth: 1,
                     strokeStyle: 'rgba(147, 147, 147, 1.0)',
                 },
-                axisActve: { strokeStyle: 'rgba(255, 100, 0, 1.0)' },
-                axisHover: { strokeStyle: 'rgba(147, 147, 147, 1.0)' },
+                axisActve: {
+                    lineWidth: 3,
+                    strokeStyle: 'rgba(79, 180, 246, 1.0)',
+                },
+                axisHover: {
+                    lineWidth: 3,
+                    strokeStyle: 'rgba(99, 200, 255, 1.0)',
+                },
                 filter: {
                     cornerRadius: 2,
-                    fillStyle: 'rgba(0, 0, 0, 1.0)',
+                    fillStyle: 'rgba(235, 100, 200, 1.0)',
                     strokeStyle: 'rgba(255, 255, 255, 1.0)',
                     width: 4,
                 },
                 filterActive: {
                     cornerRadius: 3,
-                    fillStyle: 'rgba(255, 100, 0, 1.0)',
+                    fillStyle: 'rgba(255, 120, 220, 1.0)',
+                    width: 8,
+                },
+                filterAxisHover: {
+                    cornerRadius: 2,
+                    fillStyle: 'rgba(235, 100, 200, 1.0)',
                     width: 6,
                 },
                 filterHover: {
                     cornerRadius: 2,
-                    fillStyle: 'rgba(200, 50, 0, 1.0)',
-                    width: 4,
+                    fillStyle: 'rgba(235, 100, 200, 1.0)',
+                    width: 8,
                 },
                 label: {
                     fillStyle: 'rgba(0, 0, 0, 1.0)',
@@ -1605,7 +1616,9 @@ var Hermes = (function (exports) {
                     _ixsa.type === ActionType.FilterMove ||
                     _ixsa.type === ActionType.FilterResizeAfter ||
                     _ixsa.type === ActionType.FilterResizeBefore) && _ixsa.dimIndex === i;
-                const isAxisFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionAxis && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
+                const isAxisFocused = ((_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionAxis ||
+                    (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.Filter ||
+                    (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.FilterResize) && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
                 _s[i] = _s[i] || {};
                 _s[i].label = {
                     ..._osd.label,
@@ -1631,10 +1644,13 @@ var Hermes = (function (exports) {
                     const isFilterFocused = (((_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.Filter || (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.FilterResize) &&
                         (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i &&
                         (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.filterIndex) === j);
+                    const isFilterAxisHover = isAxisActive || (isAxisFocused && !isFilterFocused);
+                    const isFilterHover = isFilterFocused && _ixsa.filterIndex === undefined;
                     const isFilterActive = _ixsa.dimIndex === i && _ixsa.filterIndex === j;
                     return {
                         ..._osa.filter,
-                        ...(!isFilterActive && isFilterFocused && !isActive ? _osa.filterHover : {}),
+                        ...(isFilterAxisHover ? _osa.filterAxisHover : {}),
+                        ...(isFilterHover ? _osa.filterHover : {}),
                         ...(isFilterActive ? _osa.filterActive : {}),
                     };
                 });

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -46,23 +46,34 @@ export const HERMES_CONFIG: t.Config = {
         lineWidth: 1,
         strokeStyle: 'rgba(147, 147, 147, 1.0)',
       },
-      axisActve: { strokeStyle: 'rgba(255, 100, 0, 1.0)' },
-      axisHover: { strokeStyle: 'rgba(147, 147, 147, 1.0)' },
+      axisActve: {
+        lineWidth: 3,
+        strokeStyle: 'rgba(79, 180, 246, 1.0)',
+      },
+      axisHover: {
+        lineWidth: 3,
+        strokeStyle: 'rgba(99, 200, 255, 1.0)',
+      },
       filter: {
         cornerRadius: 2,
-        fillStyle: 'rgba(0, 0, 0, 1.0)',
+        fillStyle: 'rgba(235, 100, 200, 1.0)',
         strokeStyle: 'rgba(255, 255, 255, 1.0)',
         width: 4,
       },
       filterActive: {
         cornerRadius: 3,
-        fillStyle: 'rgba(255, 100, 0, 1.0)',
+        fillStyle: 'rgba(255, 120, 220, 1.0)',
+        width: 8,
+      },
+      filterAxisHover: {
+        cornerRadius: 2,
+        fillStyle: 'rgba(235, 100, 200, 1.0)',
         width: 6,
       },
       filterHover: {
         cornerRadius: 2,
-        fillStyle: 'rgba(200, 50, 0, 1.0)',
-        width: 4,
+        fillStyle: 'rgba(235, 100, 200, 1.0)',
+        width: 8,
       },
       label: {
         fillStyle: 'rgba(0, 0, 0, 1.0)',

--- a/src/index.ts
+++ b/src/index.ts
@@ -560,7 +560,11 @@ class Hermes {
         _ixsa.type === t.ActionType.FilterResizeAfter ||
         _ixsa.type === t.ActionType.FilterResizeBefore
       ) && _ixsa.dimIndex === i;
-      const isAxisFocused = _ixsf?.type === t.FocusType.DimensionAxis && _ixsf?.dimIndex === i;
+      const isAxisFocused = (
+        _ixsf?.type === t.FocusType.DimensionAxis ||
+        _ixsf?.type === t.FocusType.Filter ||
+        _ixsf?.type === t.FocusType.FilterResize
+      ) && _ixsf?.dimIndex === i;
 
       _s[i] = _s[i] || {};
       _s[i].label = {
@@ -593,10 +597,13 @@ class Hermes {
           _ixsf?.dimIndex === i &&
           _ixsf?.filterIndex === j
         );
+        const isFilterAxisHover = isAxisActive || (isAxisFocused && !isFilterFocused);
+        const isFilterHover = isFilterFocused && _ixsa.filterIndex === undefined;
         const isFilterActive = _ixsa.dimIndex === i && _ixsa.filterIndex === j;
         return {
           ..._osa.filter,
-          ...(!isFilterActive && isFilterFocused && !isActive ? _osa.filterHover : {}),
+          ...(isFilterAxisHover ? _osa.filterAxisHover : {}),
+          ...(isFilterHover ? _osa.filterHover : {}),
           ...(isFilterActive ? _osa.filterActive : {}),
         };
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,6 +205,7 @@ export interface Config {
       axisHover: StyleLine;
       filter: FilterOptions;
       filterActive: FilterOptions;
+      filterAxisHover: FilterOptions;
       filterHover: FilterOptions;
       label: LabelOptions;
       labelActive: StyleText;


### PR DESCRIPTION
Currently the when hovering over axis and filters, they have independent hovering interactions. For example, if you have an axis with some filters, if you hover over the axis but not over the filter, only the axis hover styles will get applied, where as the filters remain the default style. If you hover over the filters, the axis hover style does not get applied either.

Update to link them so hovering over each other will also trigger the hover styles of the other non-direct hovering.