### PR TITLE
add custom log scale

### DIFF
--- a/src/classes/LogScale.ts
+++ b/src/classes/LogScale.ts
@@ -60,7 +60,12 @@ class LogScale extends NiceScale {
   }
 
   protected calculate(): void {
-    this.log = this.logBase === 10 ? Math.log10 : this.logBase === 2 ? Math.log2 : Math.log;
+    this.log =
+      this.logBase === 10
+        ? Math.log10
+        : this.logBase === 2
+          ? Math.log2
+          : (x) => Math.log(x) / Math.log(this.logBase);
     this.denominator = this.log === Math.log ? Math.log(this.logBase) : 1;
 
     this.minExpExact = this.log(this.minValue) / this.denominator;


### PR DESCRIPTION
Looks like the rest of the code in the `calculate` method uses `logBase` as is, but the `this.log` defaults to natural log unless user supplies `logBase` of `2` or `10`.

also `validateDimension` allows any number for the `logBase`, so there is nothing to prevent consumer from supplying other base.