### PR TITLE
[Issue-100] handle single negative value auto range

### DIFF
--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -361,13 +361,24 @@ var Hermes = (function (exports) {
         setMinMaxValues(minValue, maxValue, calculate = true) {
             /*
              * Handle the 0 range scale by padding each end of the common min/max value,
-             * based on the log base 2 of the min/max value.
+             * based on the log base 2 of the min/max value. If min/max are 0, set range to [ -1, 1 ].
              */
             if (minValue === maxValue) {
                 const value = minValue;
-                const exp = Math.log2(value);
-                minValue = 2 ** (exp - 1);
-                maxValue = value + (value - minValue);
+                if (value === 0) {
+                    minValue = -1;
+                    maxValue = 1;
+                }
+                else if (value < 0) {
+                    const exp = Math.log2(Math.abs(value));
+                    maxValue = -(2 ** (exp - 1));
+                    minValue = value - (maxValue - value);
+                }
+                else {
+                    const exp = Math.log2(value);
+                    minValue = 2 ** (exp - 1);
+                    maxValue = value + (value - minValue);
+                }
             }
             this.minValue = minValue;
             this.maxValue = maxValue;

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -362,13 +362,24 @@ class NiceScale {
     setMinMaxValues(minValue, maxValue, calculate = true) {
         /*
          * Handle the 0 range scale by padding each end of the common min/max value,
-         * based on the log base 2 of the min/max value.
+         * based on the log base 2 of the min/max value. If min/max are 0, set range to [ -1, 1 ].
          */
         if (minValue === maxValue) {
             const value = minValue;
-            const exp = Math.log2(value);
-            minValue = 2 ** (exp - 1);
-            maxValue = value + (value - minValue);
+            if (value === 0) {
+                minValue = -1;
+                maxValue = 1;
+            }
+            else if (value < 0) {
+                const exp = Math.log2(Math.abs(value));
+                maxValue = -(2 ** (exp - 1));
+                minValue = value - (maxValue - value);
+            }
+            else {
+                const exp = Math.log2(value);
+                minValue = 2 ** (exp - 1);
+                maxValue = value + (value - minValue);
+            }
         }
         this.minValue = minValue;
         this.maxValue = maxValue;

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -358,13 +358,24 @@ class NiceScale {
     setMinMaxValues(minValue, maxValue, calculate = true) {
         /*
          * Handle the 0 range scale by padding each end of the common min/max value,
-         * based on the log base 2 of the min/max value.
+         * based on the log base 2 of the min/max value. If min/max are 0, set range to [ -1, 1 ].
          */
         if (minValue === maxValue) {
             const value = minValue;
-            const exp = Math.log2(value);
-            minValue = 2 ** (exp - 1);
-            maxValue = value + (value - minValue);
+            if (value === 0) {
+                minValue = -1;
+                maxValue = 1;
+            }
+            else if (value < 0) {
+                const exp = Math.log2(Math.abs(value));
+                maxValue = -(2 ** (exp - 1));
+                minValue = value - (maxValue - value);
+            }
+            else {
+                const exp = Math.log2(value);
+                minValue = 2 ** (exp - 1);
+                maxValue = value + (value - minValue);
+            }
         }
         this.minValue = minValue;
         this.maxValue = maxValue;

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -361,13 +361,24 @@ var Hermes = (function (exports) {
         setMinMaxValues(minValue, maxValue, calculate = true) {
             /*
              * Handle the 0 range scale by padding each end of the common min/max value,
-             * based on the log base 2 of the min/max value.
+             * based on the log base 2 of the min/max value. If min/max are 0, set range to [ -1, 1 ].
              */
             if (minValue === maxValue) {
                 const value = minValue;
-                const exp = Math.log2(value);
-                minValue = 2 ** (exp - 1);
-                maxValue = value + (value - minValue);
+                if (value === 0) {
+                    minValue = -1;
+                    maxValue = 1;
+                }
+                else if (value < 0) {
+                    const exp = Math.log2(Math.abs(value));
+                    maxValue = -(2 ** (exp - 1));
+                    minValue = value - (maxValue - value);
+                }
+                else {
+                    const exp = Math.log2(value);
+                    minValue = 2 ** (exp - 1);
+                    maxValue = value + (value - minValue);
+                }
             }
             this.minValue = minValue;
             this.maxValue = maxValue;

--- a/src/classes/CategoricalScale.test.ts
+++ b/src/classes/CategoricalScale.test.ts
@@ -67,9 +67,9 @@ describe('CategoricalScale', () => {
 
     it('should calculate log values properly', () => {
       scale.testCalculate();
-      expect(scale.min).toBe(0);
-      expect(scale.max).toBe(0);
-      expect(scale.range).toBe(0);
+      expect(scale.min).toBe(-1);
+      expect(scale.max).toBe(1);
+      expect(scale.range).toBe(2);
       expect(scale.tickLabels).toStrictEqual([ 'abc', 'def', 'ghi', 'jkl', 'mno' ]);
       expect(scale.tickPadding).toBe(0);
       expect(scale.tickPos).toStrictEqual([ 0, 50, 100, 150, 200 ]);
@@ -120,9 +120,9 @@ describe('CategoricalScale', () => {
 
     it('should calculate log values properly', () => {
       scale.testCalculate();
-      expect(scale.min).toBe(0);
-      expect(scale.max).toBe(0);
-      expect(scale.range).toBe(0);
+      expect(scale.min).toBe(-1);
+      expect(scale.max).toBe(1);
+      expect(scale.range).toBe(2);
       expect(scale.tickLabels).toStrictEqual([ 'abc', 'def', 'ghi', 'jkl', 'mno' ]);
       expect(scale.tickPadding).toBe(0);
       expect(scale.tickPos).toStrictEqual([ 20, 60, 100, 140, 180 ]);
@@ -173,9 +173,9 @@ describe('CategoricalScale', () => {
 
     it('should calculate log values properly', () => {
       scale.testCalculate();
-      expect(scale.min).toBe(0);
-      expect(scale.max).toBe(0);
-      expect(scale.range).toBe(0);
+      expect(scale.min).toBe(-1);
+      expect(scale.max).toBe(1);
+      expect(scale.range).toBe(2);
       expect(scale.tickLabels).toStrictEqual([ 'mno', 'jkl', 'ghi', 'def', 'abc' ]);
       expect(scale.tickPadding).toBe(0);
       expect(scale.tickPos).toStrictEqual([ 0, 50, 100, 150, 200 ]);
@@ -226,9 +226,9 @@ describe('CategoricalScale', () => {
 
     it('should calculate log values properly', () => {
       scale.testCalculate();
-      expect(scale.min).toBe(0);
-      expect(scale.max).toBe(0);
-      expect(scale.range).toBe(0);
+      expect(scale.min).toBe(-1);
+      expect(scale.max).toBe(1);
+      expect(scale.range).toBe(2);
       expect(scale.tickLabels).toStrictEqual([ 'abc', 'def', 'ghi', 'jkl', 'mno' ]);
       expect(scale.tickPadding).toBe(0);
       expect(scale.tickPos).toStrictEqual([ 0, 50, 100, 150, 200 ]);

--- a/src/classes/NiceScale.test.ts
+++ b/src/classes/NiceScale.test.ts
@@ -99,6 +99,24 @@ describe('NiceScale class', () => {
     expect(mockCalculate).toHaveBeenCalled();
   });
 
+  it('should handle min and max values being the same and greater than 0', () => {
+    const { maxValue, minValue } = scale.testSetMinMaxValues(100, 100);
+    expect(minValue).toBeCloseTo(50);
+    expect(maxValue).toBeCloseTo(150);
+  });
+
+  it('should handle min and max values being the same and greater than 0', () => {
+    const { maxValue, minValue } = scale.testSetMinMaxValues(0, 0);
+    expect(minValue).toBe(-1);
+    expect(maxValue).toBe(1);
+  });
+
+  it('should handle min and max values being the same and less than 0', () => {
+    const { maxValue, minValue } = scale.testSetMinMaxValues(-100, -100);
+    expect(minValue).toBeCloseTo(-150);
+    expect(maxValue).toBeCloseTo(-50);
+  });
+
   it('should return nice numbers', () => {
     expect(scale.testNiceNum(1.5, true)).toBe(2);
     expect(scale.testNiceNum(1.5, false)).toBe(2);

--- a/src/classes/NiceScale.ts
+++ b/src/classes/NiceScale.ts
@@ -82,6 +82,7 @@ abstract class NiceScale {
     this.maxValue = maxValue;
     this.max = maxValue;
     this.min = minValue;
+    this.range = maxValue - minValue;
 
     if (calculate) this.calculate();
   }

--- a/src/classes/NiceScale.ts
+++ b/src/classes/NiceScale.ts
@@ -60,13 +60,22 @@ abstract class NiceScale {
   public setMinMaxValues(minValue: number, maxValue: number, calculate = true): void {
     /*
      * Handle the 0 range scale by padding each end of the common min/max value,
-     * based on the log base 2 of the min/max value.
+     * based on the log base 2 of the min/max value. If min/max are 0, set range to [ -1, 1 ].
      */
     if (minValue === maxValue) {
       const value = minValue;
-      const exp = Math.log2(value);
-      minValue = 2 ** (exp - 1);
-      maxValue = value + (value - minValue);
+      if (value === 0) {
+        minValue = -1;
+        maxValue = 1;
+      } else if (value < 0) {
+        const exp = Math.log2(Math.abs(value));
+        maxValue = -(2 ** (exp - 1));
+        minValue = value - (maxValue - value);
+      } else {
+        const exp = Math.log2(value);
+        minValue = 2 ** (exp - 1);
+        maxValue = value + (value - minValue);
+      }
     }
 
     this.minValue = minValue;


### PR DESCRIPTION
In the case of a scale with only one single value, the min / max values are going to be the same. `NiceScale` attempts to auto determine a reasonable range. Currently it only handles when the single value is a positive value (> 0).
- add support for the case when the single value is 0
- add support for the case when the single value is less than 0