### PR TITLE
Events output an InternalFilters object, config accepts updated filters

### DIFF
--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -1919,9 +1919,14 @@ var Hermes = (function (exports) {
             const _ixsa = _ix.shared.action;
             const _ixf = _ix.filters;
             const _dsa = this._.dims.shared.axes;
+            console.log('this.ix action');
+            console.log(_ixsa);
             // See if there is an existing matching filter based on % position.
+            console.log('at filter time');
+            console.log(_filters);
             const index = (_filters[key] || []).findIndex(filter => pos >= filter.p0 && pos <= filter.p1);
             if (index !== -1) {
+                console.log('index not -1');
                 _ixf.active = _filters[key][index];
                 _ixf.active.startP0 = _ixf.active.p0;
                 _ixf.active.startP1 = _ixf.active.p1;
@@ -1939,6 +1944,7 @@ var Hermes = (function (exports) {
                 }
             }
             else {
+                console.log('index is -1');
                 _ixsa.type = ActionType.FilterCreate;
                 _ixf.active = { p0: pos, p1: pos, value0: value, value1: value };
                 // Store active filter into filter list.

--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -1297,6 +1297,7 @@ var Hermes = (function (exports) {
                 mouseup: this.handleMouseUp.bind(this),
             };
             if (config === null || config === void 0 ? void 0 : config.filters) {
+                console.log('update filters from config');
                 Object.keys(this.config.filters).forEach((key) => {
                     // Store active filter into filter list.
                     this.filters[key] = [];
@@ -1389,8 +1390,6 @@ var Hermes = (function (exports) {
             this.setDimensions(this.dimensionsOriginal, false);
             if (redraw)
                 this.redraw();
-            console.log('after redraw');
-            console.log(this.filters);
         }
         setDimensions(dimensions, redraw = true) {
             // Validate that the dimensions are set properly.
@@ -1426,14 +1425,6 @@ var Hermes = (function (exports) {
                 }
                 return internal;
             });
-            if (redraw)
-                this.redraw();
-        }
-        setFilters(filters, redraw = false) {
-            console.log(this.filters);
-            console.log('changed to');
-            console.log(filters);
-            this.filters = filters;
             if (redraw)
                 this.redraw();
         }
@@ -1783,6 +1774,8 @@ var Hermes = (function (exports) {
             for (let i = 0; i < _dl.length; i++) {
                 const key = this.dimensions[i].key;
                 const filters = this.filters[key] || [];
+                console.log('my column filters');
+                console.log(filters);
                 const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
                 const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
                 const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||
@@ -1919,6 +1912,7 @@ var Hermes = (function (exports) {
         setActiveFilter(key, pos, value) {
             if (!this._)
                 return;
+            console.log('setActiveFilter');
             const _filters = this.filters;
             const _ix = this.ix;
             const _ixsa = _ix.shared.action;
@@ -1956,6 +1950,7 @@ var Hermes = (function (exports) {
             var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _m, _o;
             if (!this._)
                 return;
+            console.log('updateActiveFilter');
             const _dl = this._.dims.list;
             const _dsa = this._.dims.shared.axes;
             const _ix = this.ix;
@@ -2050,11 +2045,12 @@ var Hermes = (function (exports) {
             // Overwrite active filter to remove reference to filter in filters list.
             _ixf.active = { ...FILTER };
             _ixf.key = undefined;
-            this.cleanUpFilters();
+            // this.cleanUpFilters();
             // Make hook call back with all of the filter changes.
             (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
         }
         cleanUpFilters() {
+            console.log('cleanUpFilters');
             Object.keys(this.filters).forEach(key => {
                 const filters = this.filters[key] || [];
                 for (let i = 0; i < filters.length; i++) {

--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -70,7 +70,7 @@ var Hermes = (function (exports) {
     const HERMES_CONFIG = {
         debug: false,
         direction: Direction.Horizontal,
-        filters: new Array(),
+        filters: {},
         hooks: {},
         interactions: {
             throttleDelayMouseMove: 50,
@@ -1062,14 +1062,6 @@ var Hermes = (function (exports) {
             ? [filter.value1, filter.value0]
             : [filter.value0, filter.value1];
     };
-    const internalToFilters = (filters) => {
-        return Object.keys(filters).reduce((acc, key) => {
-            acc[key] = filters[key]
-                .map(filter => internalToFilter(filter))
-                .sort((a, b) => comparePrimitive(a[0], b[0]));
-            return acc;
-        }, {});
-    };
     const isFilterEmpty = (filter) => {
         return isNaN(filter.p0) && isNaN(filter.p1);
     };
@@ -2040,7 +2032,7 @@ var Hermes = (function (exports) {
             _ixf.key = undefined;
             this.cleanUpFilters();
             // Make hook call back with all of the filter changes.
-            (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, internalToFilters(this.filters));
+            (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
         }
         cleanUpFilters() {
             Object.keys(this.filters).forEach(key => {

--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -1381,12 +1381,16 @@ var Hermes = (function (exports) {
             const dataValidation = Hermes.validateData(data, this.dimensionsOriginal);
             if (!dataValidation.valid)
                 throw new HermesError(dataValidation.message);
+            console.log('known filters at set data');
+            console.log(this.filters);
             const filtered = removeInfinityNanSeries(data);
             this.data = filtered.data;
             this.dataCount = filtered.count;
             this.setDimensions(this.dimensionsOriginal, false);
             if (redraw)
                 this.redraw();
+            console.log('after redraw');
+            console.log(this.filters);
         }
         setDimensions(dimensions, redraw = true) {
             // Validate that the dimensions are set properly.

--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -70,6 +70,7 @@ var Hermes = (function (exports) {
     const HERMES_CONFIG = {
         debug: false,
         direction: Direction.Horizontal,
+        filters: new Array(),
         hooks: {},
         interactions: {
             throttleDelayMouseMove: 50,
@@ -1303,6 +1304,7 @@ var Hermes = (function (exports) {
                     : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
                 mouseup: this.handleMouseUp.bind(this),
             };
+            if (this.config.filters) ;
             // Enable chart
             this.enable();
         }
@@ -2022,7 +2024,7 @@ var Hermes = (function (exports) {
                 // Make corresponding filter hook callback.
                 switch (_ixsa.type) {
                     case ActionType.FilterCreate:
-                        (_f = (_e = this.config.hooks).onFilterCreate) === null || _f === void 0 ? void 0 : _f.call(_e, internalToFilter(_ixf.active));
+                        (_f = (_e = this.config.hooks).onFilterCreate) === null || _f === void 0 ? void 0 : _f.call(_e, _ixf.active);
                         break;
                     case ActionType.FilterMove:
                         (_h = (_g = this.config.hooks).onFilterMove) === null || _h === void 0 ? void 0 : _h.call(_g, internalToFilter(_ixf.active));

--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -1297,13 +1297,8 @@ var Hermes = (function (exports) {
                 mouseup: this.handleMouseUp.bind(this),
             };
             if (config === null || config === void 0 ? void 0 : config.filters) {
-                console.log('update filters from config');
                 Object.keys(this.config.filters).forEach((key) => {
-                    // Store active filter into filter list.
-                    this.filters[key] = [];
-                    this.config.filters[key].forEach(intf => {
-                        this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
-                    });
+                    this.filters[key] = this.config.filters[key];
                 });
             }
             // Enable chart
@@ -1374,13 +1369,8 @@ var Hermes = (function (exports) {
             // Set config early as setSize references it early.
             this.config = deepMerge(HERMES_CONFIG, config);
             if (config.filters) {
-                console.log('update filters from setConfig');
                 Object.keys(this.config.filters).forEach((key) => {
-                    // Store active filter into filter list.
-                    this.filters[key] = [];
-                    this.config.filters[key].forEach(intf => {
-                        this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
-                    });
+                    this.filters[key] = this.config.filters[key];
                 });
             }
             // Re-add observers as config impacts the throttling of the observer handlers.
@@ -1392,8 +1382,6 @@ var Hermes = (function (exports) {
             const dataValidation = Hermes.validateData(data, this.dimensionsOriginal);
             if (!dataValidation.valid)
                 throw new HermesError(dataValidation.message);
-            console.log('known filters at set data');
-            console.log(this.filters);
             const filtered = removeInfinityNanSeries(data);
             this.data = filtered.data;
             this.dataCount = filtered.count;
@@ -1784,10 +1772,6 @@ var Hermes = (function (exports) {
             for (let i = 0; i < _dl.length; i++) {
                 const key = this.dimensions[i].key;
                 const filters = this.filters[key] || [];
-                if (filters.length) {
-                    console.log('my column filters');
-                    console.log(filters);
-                }
                 const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
                 const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
                 const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||
@@ -1924,7 +1908,6 @@ var Hermes = (function (exports) {
         setActiveFilter(key, pos, value) {
             if (!this._)
                 return;
-            console.log('setActiveFilter');
             const _filters = this.filters;
             const _ix = this.ix;
             const _ixsa = _ix.shared.action;
@@ -1962,7 +1945,6 @@ var Hermes = (function (exports) {
             var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _m, _o;
             if (!this._)
                 return;
-            console.log('updateActiveFilter');
             const _dl = this._.dims.list;
             const _dsa = this._.dims.shared.axes;
             const _ix = this.ix;
@@ -2057,12 +2039,11 @@ var Hermes = (function (exports) {
             // Overwrite active filter to remove reference to filter in filters list.
             _ixf.active = { ...FILTER };
             _ixf.key = undefined;
-            // this.cleanUpFilters();
+            this.cleanUpFilters();
             // Make hook call back with all of the filter changes.
             (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
         }
         cleanUpFilters() {
-            console.log('cleanUpFilters');
             Object.keys(this.filters).forEach(key => {
                 const filters = this.filters[key] || [];
                 for (let i = 0; i < filters.length; i++) {

--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -1297,19 +1297,12 @@ var Hermes = (function (exports) {
                 mouseup: this.handleMouseUp.bind(this),
             };
             if (config === null || config === void 0 ? void 0 : config.filters) {
-                // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
-                // setActiveFilter
-                console.log(this.config.filters);
                 Object.keys(this.config.filters).forEach((key) => {
-                    // const addFilter = this.config.filters[key];
-                    // this.setActiveFilter(key, addFilter., addFilter.range);
                     // Store active filter into filter list.
-                    console.log(key);
                     this.filters[key] = [];
                     this.config.filters[key].forEach(intf => {
                         this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
                     });
-                    // _ixsa.filterIndex = _filters[key].length - 1;
                 });
             }
             // Enable chart
@@ -1429,6 +1422,14 @@ var Hermes = (function (exports) {
                 }
                 return internal;
             });
+            if (redraw)
+                this.redraw();
+        }
+        setFilters(filters, redraw = false) {
+            console.log(this.filters);
+            console.log('changed to');
+            console.log(filters);
+            this.filters = filters;
             if (redraw)
                 this.redraw();
         }
@@ -1919,14 +1920,9 @@ var Hermes = (function (exports) {
             const _ixsa = _ix.shared.action;
             const _ixf = _ix.filters;
             const _dsa = this._.dims.shared.axes;
-            console.log('this.ix action');
-            console.log(_ixsa);
             // See if there is an existing matching filter based on % position.
-            console.log('at filter time');
-            console.log(_filters);
             const index = (_filters[key] || []).findIndex(filter => pos >= filter.p0 && pos <= filter.p1);
             if (index !== -1) {
-                console.log('index not -1');
                 _ixf.active = _filters[key][index];
                 _ixf.active.startP0 = _ixf.active.p0;
                 _ixf.active.startP1 = _ixf.active.p1;
@@ -1944,7 +1940,6 @@ var Hermes = (function (exports) {
                 }
             }
             else {
-                console.log('index is -1');
                 _ixsa.type = ActionType.FilterCreate;
                 _ixf.active = { p0: pos, p1: pos, value0: value, value1: value };
                 // Store active filter into filter list.

--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -1296,7 +1296,7 @@ var Hermes = (function (exports) {
                     : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
                 mouseup: this.handleMouseUp.bind(this),
             };
-            if (this.config.filters) {
+            if (config === null || config === void 0 ? void 0 : config.filters) {
                 // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
                 // setActiveFilter
                 console.log(this.config.filters);

--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -1296,7 +1296,13 @@ var Hermes = (function (exports) {
                     : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
                 mouseup: this.handleMouseUp.bind(this),
             };
-            if (this.config.filters) ;
+            if (this.config.filters) {
+                // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
+                // setActiveFilter
+                Object.keys(this.config.filters).forEach((key) => {
+                    this.filters[key] = this.config.filters[key];
+                });
+            }
             // Enable chart
             this.enable();
         }

--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -1299,8 +1299,17 @@ var Hermes = (function (exports) {
             if (this.config.filters) {
                 // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
                 // setActiveFilter
+                console.log(this.config.filters);
                 Object.keys(this.config.filters).forEach((key) => {
-                    this.filters[key] = this.config.filters[key];
+                    // const addFilter = this.config.filters[key];
+                    // this.setActiveFilter(key, addFilter., addFilter.range);
+                    // Store active filter into filter list.
+                    console.log(key);
+                    this.filters[key] = [];
+                    this.config.filters[key].forEach(intf => {
+                        this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
+                    });
+                    // _ixsa.filterIndex = _filters[key].length - 1;
                 });
             }
             // Enable chart

--- a/demos/lib/hermes.iife.js
+++ b/demos/lib/hermes.iife.js
@@ -1373,6 +1373,16 @@ var Hermes = (function (exports) {
         setConfig(config = {}, redraw = true) {
             // Set config early as setSize references it early.
             this.config = deepMerge(HERMES_CONFIG, config);
+            if (config.filters) {
+                console.log('update filters from setConfig');
+                Object.keys(this.config.filters).forEach((key) => {
+                    // Store active filter into filter list.
+                    this.filters[key] = [];
+                    this.config.filters[key].forEach(intf => {
+                        this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
+                    });
+                });
+            }
             // Re-add observers as config impacts the throttling of the observer handlers.
             this.addObservers();
             if (redraw)
@@ -1774,8 +1784,10 @@ var Hermes = (function (exports) {
             for (let i = 0; i < _dl.length; i++) {
                 const key = this.dimensions[i].key;
                 const filters = this.filters[key] || [];
-                console.log('my column filters');
-                console.log(filters);
+                if (filters.length) {
+                    console.log('my column filters');
+                    console.log(filters);
+                }
                 const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
                 const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
                 const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -1300,8 +1300,17 @@ class Hermes {
         if (this.config.filters) {
             // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
             // setActiveFilter
+            console.log(this.config.filters);
             Object.keys(this.config.filters).forEach((key) => {
-                this.filters[key] = this.config.filters[key];
+                // const addFilter = this.config.filters[key];
+                // this.setActiveFilter(key, addFilter., addFilter.range);
+                // Store active filter into filter list.
+                console.log(key);
+                this.filters[key] = [];
+                this.config.filters[key].forEach(intf => {
+                    this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
+                });
+                // _ixsa.filterIndex = _filters[key].length - 1;
             });
         }
         // Enable chart

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -1374,6 +1374,16 @@ class Hermes {
     setConfig(config = {}, redraw = true) {
         // Set config early as setSize references it early.
         this.config = deepMerge(HERMES_CONFIG, config);
+        if (config.filters) {
+            console.log('update filters from setConfig');
+            Object.keys(this.config.filters).forEach((key) => {
+                // Store active filter into filter list.
+                this.filters[key] = [];
+                this.config.filters[key].forEach(intf => {
+                    this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
+                });
+            });
+        }
         // Re-add observers as config impacts the throttling of the observer handlers.
         this.addObservers();
         if (redraw)
@@ -1775,8 +1785,10 @@ class Hermes {
         for (let i = 0; i < _dl.length; i++) {
             const key = this.dimensions[i].key;
             const filters = this.filters[key] || [];
-            console.log('my column filters');
-            console.log(filters);
+            if (filters.length) {
+                console.log('my column filters');
+                console.log(filters);
+            }
             const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
             const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
             const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -1298,13 +1298,8 @@ class Hermes {
             mouseup: this.handleMouseUp.bind(this),
         };
         if (config === null || config === void 0 ? void 0 : config.filters) {
-            console.log('update filters from config');
             Object.keys(this.config.filters).forEach((key) => {
-                // Store active filter into filter list.
-                this.filters[key] = [];
-                this.config.filters[key].forEach(intf => {
-                    this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
-                });
+                this.filters[key] = this.config.filters[key];
             });
         }
         // Enable chart
@@ -1375,13 +1370,8 @@ class Hermes {
         // Set config early as setSize references it early.
         this.config = deepMerge(HERMES_CONFIG, config);
         if (config.filters) {
-            console.log('update filters from setConfig');
             Object.keys(this.config.filters).forEach((key) => {
-                // Store active filter into filter list.
-                this.filters[key] = [];
-                this.config.filters[key].forEach(intf => {
-                    this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
-                });
+                this.filters[key] = this.config.filters[key];
             });
         }
         // Re-add observers as config impacts the throttling of the observer handlers.
@@ -1393,8 +1383,6 @@ class Hermes {
         const dataValidation = Hermes.validateData(data, this.dimensionsOriginal);
         if (!dataValidation.valid)
             throw new HermesError(dataValidation.message);
-        console.log('known filters at set data');
-        console.log(this.filters);
         const filtered = removeInfinityNanSeries(data);
         this.data = filtered.data;
         this.dataCount = filtered.count;
@@ -1785,10 +1773,6 @@ class Hermes {
         for (let i = 0; i < _dl.length; i++) {
             const key = this.dimensions[i].key;
             const filters = this.filters[key] || [];
-            if (filters.length) {
-                console.log('my column filters');
-                console.log(filters);
-            }
             const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
             const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
             const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||
@@ -1925,7 +1909,6 @@ class Hermes {
     setActiveFilter(key, pos, value) {
         if (!this._)
             return;
-        console.log('setActiveFilter');
         const _filters = this.filters;
         const _ix = this.ix;
         const _ixsa = _ix.shared.action;
@@ -1963,7 +1946,6 @@ class Hermes {
         var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _m, _o;
         if (!this._)
             return;
-        console.log('updateActiveFilter');
         const _dl = this._.dims.list;
         const _dsa = this._.dims.shared.axes;
         const _ix = this.ix;
@@ -2058,12 +2040,11 @@ class Hermes {
         // Overwrite active filter to remove reference to filter in filters list.
         _ixf.active = { ...FILTER };
         _ixf.key = undefined;
-        // this.cleanUpFilters();
+        this.cleanUpFilters();
         // Make hook call back with all of the filter changes.
         (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
     }
     cleanUpFilters() {
-        console.log('cleanUpFilters');
         Object.keys(this.filters).forEach(key => {
             const filters = this.filters[key] || [];
             for (let i = 0; i < filters.length; i++) {

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -1297,7 +1297,13 @@ class Hermes {
                 : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
             mouseup: this.handleMouseUp.bind(this),
         };
-        if (this.config.filters) ;
+        if (this.config.filters) {
+            // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
+            // setActiveFilter
+            Object.keys(this.config.filters).forEach((key) => {
+                this.filters[key] = this.config.filters[key];
+            });
+        }
         // Enable chart
         this.enable();
     }

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -71,7 +71,7 @@ const TRUNCATE_SUFFIX = '...';
 const HERMES_CONFIG = {
     debug: false,
     direction: Direction.Horizontal,
-    filters: new Array(),
+    filters: {},
     hooks: {},
     interactions: {
         throttleDelayMouseMove: 50,
@@ -1063,14 +1063,6 @@ const internalToFilter = (filter) => {
         ? [filter.value1, filter.value0]
         : [filter.value0, filter.value1];
 };
-const internalToFilters = (filters) => {
-    return Object.keys(filters).reduce((acc, key) => {
-        acc[key] = filters[key]
-            .map(filter => internalToFilter(filter))
-            .sort((a, b) => comparePrimitive(a[0], b[0]));
-        return acc;
-    }, {});
-};
 const isFilterEmpty = (filter) => {
     return isNaN(filter.p0) && isNaN(filter.p1);
 };
@@ -2041,7 +2033,7 @@ class Hermes {
         _ixf.key = undefined;
         this.cleanUpFilters();
         // Make hook call back with all of the filter changes.
-        (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, internalToFilters(this.filters));
+        (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
     }
     cleanUpFilters() {
         Object.keys(this.filters).forEach(key => {

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -71,6 +71,7 @@ const TRUNCATE_SUFFIX = '...';
 const HERMES_CONFIG = {
     debug: false,
     direction: Direction.Horizontal,
+    filters: new Array(),
     hooks: {},
     interactions: {
         throttleDelayMouseMove: 50,
@@ -1304,6 +1305,7 @@ class Hermes {
                 : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
             mouseup: this.handleMouseUp.bind(this),
         };
+        if (this.config.filters) ;
         // Enable chart
         this.enable();
     }
@@ -2023,7 +2025,7 @@ class Hermes {
             // Make corresponding filter hook callback.
             switch (_ixsa.type) {
                 case ActionType.FilterCreate:
-                    (_f = (_e = this.config.hooks).onFilterCreate) === null || _f === void 0 ? void 0 : _f.call(_e, internalToFilter(_ixf.active));
+                    (_f = (_e = this.config.hooks).onFilterCreate) === null || _f === void 0 ? void 0 : _f.call(_e, _ixf.active);
                     break;
                 case ActionType.FilterMove:
                     (_h = (_g = this.config.hooks).onFilterMove) === null || _h === void 0 ? void 0 : _h.call(_g, internalToFilter(_ixf.active));

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -1297,7 +1297,7 @@ class Hermes {
                 : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
             mouseup: this.handleMouseUp.bind(this),
         };
-        if (this.config.filters) {
+        if (config === null || config === void 0 ? void 0 : config.filters) {
             // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
             // setActiveFilter
             console.log(this.config.filters);

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -1382,12 +1382,16 @@ class Hermes {
         const dataValidation = Hermes.validateData(data, this.dimensionsOriginal);
         if (!dataValidation.valid)
             throw new HermesError(dataValidation.message);
+        console.log('known filters at set data');
+        console.log(this.filters);
         const filtered = removeInfinityNanSeries(data);
         this.data = filtered.data;
         this.dataCount = filtered.count;
         this.setDimensions(this.dimensionsOriginal, false);
         if (redraw)
             this.redraw();
+        console.log('after redraw');
+        console.log(this.filters);
     }
     setDimensions(dimensions, redraw = true) {
         // Validate that the dimensions are set properly.

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -1298,19 +1298,12 @@ class Hermes {
             mouseup: this.handleMouseUp.bind(this),
         };
         if (config === null || config === void 0 ? void 0 : config.filters) {
-            // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
-            // setActiveFilter
-            console.log(this.config.filters);
             Object.keys(this.config.filters).forEach((key) => {
-                // const addFilter = this.config.filters[key];
-                // this.setActiveFilter(key, addFilter., addFilter.range);
                 // Store active filter into filter list.
-                console.log(key);
                 this.filters[key] = [];
                 this.config.filters[key].forEach(intf => {
                     this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
                 });
-                // _ixsa.filterIndex = _filters[key].length - 1;
             });
         }
         // Enable chart
@@ -1430,6 +1423,14 @@ class Hermes {
             }
             return internal;
         });
+        if (redraw)
+            this.redraw();
+    }
+    setFilters(filters, redraw = false) {
+        console.log(this.filters);
+        console.log('changed to');
+        console.log(filters);
+        this.filters = filters;
         if (redraw)
             this.redraw();
     }
@@ -1920,14 +1921,9 @@ class Hermes {
         const _ixsa = _ix.shared.action;
         const _ixf = _ix.filters;
         const _dsa = this._.dims.shared.axes;
-        console.log('this.ix action');
-        console.log(_ixsa);
         // See if there is an existing matching filter based on % position.
-        console.log('at filter time');
-        console.log(_filters);
         const index = (_filters[key] || []).findIndex(filter => pos >= filter.p0 && pos <= filter.p1);
         if (index !== -1) {
-            console.log('index not -1');
             _ixf.active = _filters[key][index];
             _ixf.active.startP0 = _ixf.active.p0;
             _ixf.active.startP1 = _ixf.active.p1;
@@ -1945,7 +1941,6 @@ class Hermes {
             }
         }
         else {
-            console.log('index is -1');
             _ixsa.type = ActionType.FilterCreate;
             _ixf.active = { p0: pos, p1: pos, value0: value, value1: value };
             // Store active filter into filter list.

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -1920,9 +1920,14 @@ class Hermes {
         const _ixsa = _ix.shared.action;
         const _ixf = _ix.filters;
         const _dsa = this._.dims.shared.axes;
+        console.log('this.ix action');
+        console.log(_ixsa);
         // See if there is an existing matching filter based on % position.
+        console.log('at filter time');
+        console.log(_filters);
         const index = (_filters[key] || []).findIndex(filter => pos >= filter.p0 && pos <= filter.p1);
         if (index !== -1) {
+            console.log('index not -1');
             _ixf.active = _filters[key][index];
             _ixf.active.startP0 = _ixf.active.p0;
             _ixf.active.startP1 = _ixf.active.p1;
@@ -1940,6 +1945,7 @@ class Hermes {
             }
         }
         else {
+            console.log('index is -1');
             _ixsa.type = ActionType.FilterCreate;
             _ixf.active = { p0: pos, p1: pos, value0: value, value1: value };
             // Store active filter into filter list.

--- a/dist/hermes.cjs.js
+++ b/dist/hermes.cjs.js
@@ -1298,6 +1298,7 @@ class Hermes {
             mouseup: this.handleMouseUp.bind(this),
         };
         if (config === null || config === void 0 ? void 0 : config.filters) {
+            console.log('update filters from config');
             Object.keys(this.config.filters).forEach((key) => {
                 // Store active filter into filter list.
                 this.filters[key] = [];
@@ -1390,8 +1391,6 @@ class Hermes {
         this.setDimensions(this.dimensionsOriginal, false);
         if (redraw)
             this.redraw();
-        console.log('after redraw');
-        console.log(this.filters);
     }
     setDimensions(dimensions, redraw = true) {
         // Validate that the dimensions are set properly.
@@ -1427,14 +1426,6 @@ class Hermes {
             }
             return internal;
         });
-        if (redraw)
-            this.redraw();
-    }
-    setFilters(filters, redraw = false) {
-        console.log(this.filters);
-        console.log('changed to');
-        console.log(filters);
-        this.filters = filters;
         if (redraw)
             this.redraw();
     }
@@ -1784,6 +1775,8 @@ class Hermes {
         for (let i = 0; i < _dl.length; i++) {
             const key = this.dimensions[i].key;
             const filters = this.filters[key] || [];
+            console.log('my column filters');
+            console.log(filters);
             const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
             const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
             const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||
@@ -1920,6 +1913,7 @@ class Hermes {
     setActiveFilter(key, pos, value) {
         if (!this._)
             return;
+        console.log('setActiveFilter');
         const _filters = this.filters;
         const _ix = this.ix;
         const _ixsa = _ix.shared.action;
@@ -1957,6 +1951,7 @@ class Hermes {
         var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _m, _o;
         if (!this._)
             return;
+        console.log('updateActiveFilter');
         const _dl = this._.dims.list;
         const _dsa = this._.dims.shared.axes;
         const _ix = this.ix;
@@ -2051,11 +2046,12 @@ class Hermes {
         // Overwrite active filter to remove reference to filter in filters list.
         _ixf.active = { ...FILTER };
         _ixf.key = undefined;
-        this.cleanUpFilters();
+        // this.cleanUpFilters();
         // Make hook call back with all of the filter changes.
         (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
     }
     cleanUpFilters() {
+        console.log('cleanUpFilters');
         Object.keys(this.filters).forEach(key => {
             const filters = this.filters[key] || [];
             for (let i = 0; i < filters.length; i++) {

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -67,7 +67,7 @@ const TRUNCATE_SUFFIX = '...';
 const HERMES_CONFIG = {
     debug: false,
     direction: Direction.Horizontal,
-    filters: new Array(),
+    filters: {},
     hooks: {},
     interactions: {
         throttleDelayMouseMove: 50,
@@ -1059,14 +1059,6 @@ const internalToFilter = (filter) => {
         ? [filter.value1, filter.value0]
         : [filter.value0, filter.value1];
 };
-const internalToFilters = (filters) => {
-    return Object.keys(filters).reduce((acc, key) => {
-        acc[key] = filters[key]
-            .map(filter => internalToFilter(filter))
-            .sort((a, b) => comparePrimitive(a[0], b[0]));
-        return acc;
-    }, {});
-};
 const isFilterEmpty = (filter) => {
     return isNaN(filter.p0) && isNaN(filter.p1);
 };
@@ -2037,7 +2029,7 @@ class Hermes {
         _ixf.key = undefined;
         this.cleanUpFilters();
         // Make hook call back with all of the filter changes.
-        (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, internalToFilters(this.filters));
+        (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
     }
     cleanUpFilters() {
         Object.keys(this.filters).forEach(key => {

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -1294,19 +1294,12 @@ class Hermes {
             mouseup: this.handleMouseUp.bind(this),
         };
         if (config === null || config === void 0 ? void 0 : config.filters) {
-            // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
-            // setActiveFilter
-            console.log(this.config.filters);
             Object.keys(this.config.filters).forEach((key) => {
-                // const addFilter = this.config.filters[key];
-                // this.setActiveFilter(key, addFilter., addFilter.range);
                 // Store active filter into filter list.
-                console.log(key);
                 this.filters[key] = [];
                 this.config.filters[key].forEach(intf => {
                     this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
                 });
-                // _ixsa.filterIndex = _filters[key].length - 1;
             });
         }
         // Enable chart
@@ -1426,6 +1419,14 @@ class Hermes {
             }
             return internal;
         });
+        if (redraw)
+            this.redraw();
+    }
+    setFilters(filters, redraw = false) {
+        console.log(this.filters);
+        console.log('changed to');
+        console.log(filters);
+        this.filters = filters;
         if (redraw)
             this.redraw();
     }
@@ -1916,14 +1917,9 @@ class Hermes {
         const _ixsa = _ix.shared.action;
         const _ixf = _ix.filters;
         const _dsa = this._.dims.shared.axes;
-        console.log('this.ix action');
-        console.log(_ixsa);
         // See if there is an existing matching filter based on % position.
-        console.log('at filter time');
-        console.log(_filters);
         const index = (_filters[key] || []).findIndex(filter => pos >= filter.p0 && pos <= filter.p1);
         if (index !== -1) {
-            console.log('index not -1');
             _ixf.active = _filters[key][index];
             _ixf.active.startP0 = _ixf.active.p0;
             _ixf.active.startP1 = _ixf.active.p1;
@@ -1941,7 +1937,6 @@ class Hermes {
             }
         }
         else {
-            console.log('index is -1');
             _ixsa.type = ActionType.FilterCreate;
             _ixf.active = { p0: pos, p1: pos, value0: value, value1: value };
             // Store active filter into filter list.

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -1294,6 +1294,7 @@ class Hermes {
             mouseup: this.handleMouseUp.bind(this),
         };
         if (config === null || config === void 0 ? void 0 : config.filters) {
+            console.log('update filters from config');
             Object.keys(this.config.filters).forEach((key) => {
                 // Store active filter into filter list.
                 this.filters[key] = [];
@@ -1386,8 +1387,6 @@ class Hermes {
         this.setDimensions(this.dimensionsOriginal, false);
         if (redraw)
             this.redraw();
-        console.log('after redraw');
-        console.log(this.filters);
     }
     setDimensions(dimensions, redraw = true) {
         // Validate that the dimensions are set properly.
@@ -1423,14 +1422,6 @@ class Hermes {
             }
             return internal;
         });
-        if (redraw)
-            this.redraw();
-    }
-    setFilters(filters, redraw = false) {
-        console.log(this.filters);
-        console.log('changed to');
-        console.log(filters);
-        this.filters = filters;
         if (redraw)
             this.redraw();
     }
@@ -1780,6 +1771,8 @@ class Hermes {
         for (let i = 0; i < _dl.length; i++) {
             const key = this.dimensions[i].key;
             const filters = this.filters[key] || [];
+            console.log('my column filters');
+            console.log(filters);
             const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
             const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
             const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||
@@ -1916,6 +1909,7 @@ class Hermes {
     setActiveFilter(key, pos, value) {
         if (!this._)
             return;
+        console.log('setActiveFilter');
         const _filters = this.filters;
         const _ix = this.ix;
         const _ixsa = _ix.shared.action;
@@ -1953,6 +1947,7 @@ class Hermes {
         var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _m, _o;
         if (!this._)
             return;
+        console.log('updateActiveFilter');
         const _dl = this._.dims.list;
         const _dsa = this._.dims.shared.axes;
         const _ix = this.ix;
@@ -2047,11 +2042,12 @@ class Hermes {
         // Overwrite active filter to remove reference to filter in filters list.
         _ixf.active = { ...FILTER };
         _ixf.key = undefined;
-        this.cleanUpFilters();
+        // this.cleanUpFilters();
         // Make hook call back with all of the filter changes.
         (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
     }
     cleanUpFilters() {
+        console.log('cleanUpFilters');
         Object.keys(this.filters).forEach(key => {
             const filters = this.filters[key] || [];
             for (let i = 0; i < filters.length; i++) {

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -1370,6 +1370,16 @@ class Hermes {
     setConfig(config = {}, redraw = true) {
         // Set config early as setSize references it early.
         this.config = deepMerge(HERMES_CONFIG, config);
+        if (config.filters) {
+            console.log('update filters from setConfig');
+            Object.keys(this.config.filters).forEach((key) => {
+                // Store active filter into filter list.
+                this.filters[key] = [];
+                this.config.filters[key].forEach(intf => {
+                    this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
+                });
+            });
+        }
         // Re-add observers as config impacts the throttling of the observer handlers.
         this.addObservers();
         if (redraw)
@@ -1771,8 +1781,10 @@ class Hermes {
         for (let i = 0; i < _dl.length; i++) {
             const key = this.dimensions[i].key;
             const filters = this.filters[key] || [];
-            console.log('my column filters');
-            console.log(filters);
+            if (filters.length) {
+                console.log('my column filters');
+                console.log(filters);
+            }
             const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
             const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
             const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -1378,12 +1378,16 @@ class Hermes {
         const dataValidation = Hermes.validateData(data, this.dimensionsOriginal);
         if (!dataValidation.valid)
             throw new HermesError(dataValidation.message);
+        console.log('known filters at set data');
+        console.log(this.filters);
         const filtered = removeInfinityNanSeries(data);
         this.data = filtered.data;
         this.dataCount = filtered.count;
         this.setDimensions(this.dimensionsOriginal, false);
         if (redraw)
             this.redraw();
+        console.log('after redraw');
+        console.log(this.filters);
     }
     setDimensions(dimensions, redraw = true) {
         // Validate that the dimensions are set properly.

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -1293,7 +1293,7 @@ class Hermes {
                 : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
             mouseup: this.handleMouseUp.bind(this),
         };
-        if (this.config.filters) {
+        if (config === null || config === void 0 ? void 0 : config.filters) {
             // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
             // setActiveFilter
             console.log(this.config.filters);

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -1296,8 +1296,17 @@ class Hermes {
         if (this.config.filters) {
             // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
             // setActiveFilter
+            console.log(this.config.filters);
             Object.keys(this.config.filters).forEach((key) => {
-                this.filters[key] = this.config.filters[key];
+                // const addFilter = this.config.filters[key];
+                // this.setActiveFilter(key, addFilter., addFilter.range);
+                // Store active filter into filter list.
+                console.log(key);
+                this.filters[key] = [];
+                this.config.filters[key].forEach(intf => {
+                    this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
+                });
+                // _ixsa.filterIndex = _filters[key].length - 1;
             });
         }
         // Enable chart

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -67,6 +67,7 @@ const TRUNCATE_SUFFIX = '...';
 const HERMES_CONFIG = {
     debug: false,
     direction: Direction.Horizontal,
+    filters: new Array(),
     hooks: {},
     interactions: {
         throttleDelayMouseMove: 50,
@@ -1300,6 +1301,7 @@ class Hermes {
                 : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
             mouseup: this.handleMouseUp.bind(this),
         };
+        if (this.config.filters) ;
         // Enable chart
         this.enable();
     }
@@ -2019,7 +2021,7 @@ class Hermes {
             // Make corresponding filter hook callback.
             switch (_ixsa.type) {
                 case ActionType.FilterCreate:
-                    (_f = (_e = this.config.hooks).onFilterCreate) === null || _f === void 0 ? void 0 : _f.call(_e, internalToFilter(_ixf.active));
+                    (_f = (_e = this.config.hooks).onFilterCreate) === null || _f === void 0 ? void 0 : _f.call(_e, _ixf.active);
                     break;
                 case ActionType.FilterMove:
                     (_h = (_g = this.config.hooks).onFilterMove) === null || _h === void 0 ? void 0 : _h.call(_g, internalToFilter(_ixf.active));

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -1916,9 +1916,14 @@ class Hermes {
         const _ixsa = _ix.shared.action;
         const _ixf = _ix.filters;
         const _dsa = this._.dims.shared.axes;
+        console.log('this.ix action');
+        console.log(_ixsa);
         // See if there is an existing matching filter based on % position.
+        console.log('at filter time');
+        console.log(_filters);
         const index = (_filters[key] || []).findIndex(filter => pos >= filter.p0 && pos <= filter.p1);
         if (index !== -1) {
+            console.log('index not -1');
             _ixf.active = _filters[key][index];
             _ixf.active.startP0 = _ixf.active.p0;
             _ixf.active.startP1 = _ixf.active.p1;
@@ -1936,6 +1941,7 @@ class Hermes {
             }
         }
         else {
+            console.log('index is -1');
             _ixsa.type = ActionType.FilterCreate;
             _ixf.active = { p0: pos, p1: pos, value0: value, value1: value };
             // Store active filter into filter list.

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -1294,13 +1294,8 @@ class Hermes {
             mouseup: this.handleMouseUp.bind(this),
         };
         if (config === null || config === void 0 ? void 0 : config.filters) {
-            console.log('update filters from config');
             Object.keys(this.config.filters).forEach((key) => {
-                // Store active filter into filter list.
-                this.filters[key] = [];
-                this.config.filters[key].forEach(intf => {
-                    this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
-                });
+                this.filters[key] = this.config.filters[key];
             });
         }
         // Enable chart
@@ -1371,13 +1366,8 @@ class Hermes {
         // Set config early as setSize references it early.
         this.config = deepMerge(HERMES_CONFIG, config);
         if (config.filters) {
-            console.log('update filters from setConfig');
             Object.keys(this.config.filters).forEach((key) => {
-                // Store active filter into filter list.
-                this.filters[key] = [];
-                this.config.filters[key].forEach(intf => {
-                    this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
-                });
+                this.filters[key] = this.config.filters[key];
             });
         }
         // Re-add observers as config impacts the throttling of the observer handlers.
@@ -1389,8 +1379,6 @@ class Hermes {
         const dataValidation = Hermes.validateData(data, this.dimensionsOriginal);
         if (!dataValidation.valid)
             throw new HermesError(dataValidation.message);
-        console.log('known filters at set data');
-        console.log(this.filters);
         const filtered = removeInfinityNanSeries(data);
         this.data = filtered.data;
         this.dataCount = filtered.count;
@@ -1781,10 +1769,6 @@ class Hermes {
         for (let i = 0; i < _dl.length; i++) {
             const key = this.dimensions[i].key;
             const filters = this.filters[key] || [];
-            if (filters.length) {
-                console.log('my column filters');
-                console.log(filters);
-            }
             const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
             const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
             const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||
@@ -1921,7 +1905,6 @@ class Hermes {
     setActiveFilter(key, pos, value) {
         if (!this._)
             return;
-        console.log('setActiveFilter');
         const _filters = this.filters;
         const _ix = this.ix;
         const _ixsa = _ix.shared.action;
@@ -1959,7 +1942,6 @@ class Hermes {
         var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _m, _o;
         if (!this._)
             return;
-        console.log('updateActiveFilter');
         const _dl = this._.dims.list;
         const _dsa = this._.dims.shared.axes;
         const _ix = this.ix;
@@ -2054,12 +2036,11 @@ class Hermes {
         // Overwrite active filter to remove reference to filter in filters list.
         _ixf.active = { ...FILTER };
         _ixf.key = undefined;
-        // this.cleanUpFilters();
+        this.cleanUpFilters();
         // Make hook call back with all of the filter changes.
         (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
     }
     cleanUpFilters() {
-        console.log('cleanUpFilters');
         Object.keys(this.filters).forEach(key => {
             const filters = this.filters[key] || [];
             for (let i = 0; i < filters.length; i++) {

--- a/dist/hermes.esm.js
+++ b/dist/hermes.esm.js
@@ -1293,7 +1293,13 @@ class Hermes {
                 : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
             mouseup: this.handleMouseUp.bind(this),
         };
-        if (this.config.filters) ;
+        if (this.config.filters) {
+            // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
+            // setActiveFilter
+            Object.keys(this.config.filters).forEach((key) => {
+                this.filters[key] = this.config.filters[key];
+            });
+        }
         // Enable chart
         this.enable();
     }

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -1919,9 +1919,14 @@ var Hermes = (function (exports) {
             const _ixsa = _ix.shared.action;
             const _ixf = _ix.filters;
             const _dsa = this._.dims.shared.axes;
+            console.log('this.ix action');
+            console.log(_ixsa);
             // See if there is an existing matching filter based on % position.
+            console.log('at filter time');
+            console.log(_filters);
             const index = (_filters[key] || []).findIndex(filter => pos >= filter.p0 && pos <= filter.p1);
             if (index !== -1) {
+                console.log('index not -1');
                 _ixf.active = _filters[key][index];
                 _ixf.active.startP0 = _ixf.active.p0;
                 _ixf.active.startP1 = _ixf.active.p1;
@@ -1939,6 +1944,7 @@ var Hermes = (function (exports) {
                 }
             }
             else {
+                console.log('index is -1');
                 _ixsa.type = ActionType.FilterCreate;
                 _ixf.active = { p0: pos, p1: pos, value0: value, value1: value };
                 // Store active filter into filter list.

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -1297,6 +1297,7 @@ var Hermes = (function (exports) {
                 mouseup: this.handleMouseUp.bind(this),
             };
             if (config === null || config === void 0 ? void 0 : config.filters) {
+                console.log('update filters from config');
                 Object.keys(this.config.filters).forEach((key) => {
                     // Store active filter into filter list.
                     this.filters[key] = [];
@@ -1389,8 +1390,6 @@ var Hermes = (function (exports) {
             this.setDimensions(this.dimensionsOriginal, false);
             if (redraw)
                 this.redraw();
-            console.log('after redraw');
-            console.log(this.filters);
         }
         setDimensions(dimensions, redraw = true) {
             // Validate that the dimensions are set properly.
@@ -1426,14 +1425,6 @@ var Hermes = (function (exports) {
                 }
                 return internal;
             });
-            if (redraw)
-                this.redraw();
-        }
-        setFilters(filters, redraw = false) {
-            console.log(this.filters);
-            console.log('changed to');
-            console.log(filters);
-            this.filters = filters;
             if (redraw)
                 this.redraw();
         }
@@ -1783,6 +1774,8 @@ var Hermes = (function (exports) {
             for (let i = 0; i < _dl.length; i++) {
                 const key = this.dimensions[i].key;
                 const filters = this.filters[key] || [];
+                console.log('my column filters');
+                console.log(filters);
                 const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
                 const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
                 const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||
@@ -1919,6 +1912,7 @@ var Hermes = (function (exports) {
         setActiveFilter(key, pos, value) {
             if (!this._)
                 return;
+            console.log('setActiveFilter');
             const _filters = this.filters;
             const _ix = this.ix;
             const _ixsa = _ix.shared.action;
@@ -1956,6 +1950,7 @@ var Hermes = (function (exports) {
             var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _m, _o;
             if (!this._)
                 return;
+            console.log('updateActiveFilter');
             const _dl = this._.dims.list;
             const _dsa = this._.dims.shared.axes;
             const _ix = this.ix;
@@ -2050,11 +2045,12 @@ var Hermes = (function (exports) {
             // Overwrite active filter to remove reference to filter in filters list.
             _ixf.active = { ...FILTER };
             _ixf.key = undefined;
-            this.cleanUpFilters();
+            // this.cleanUpFilters();
             // Make hook call back with all of the filter changes.
             (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
         }
         cleanUpFilters() {
+            console.log('cleanUpFilters');
             Object.keys(this.filters).forEach(key => {
                 const filters = this.filters[key] || [];
                 for (let i = 0; i < filters.length; i++) {

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -70,7 +70,7 @@ var Hermes = (function (exports) {
     const HERMES_CONFIG = {
         debug: false,
         direction: Direction.Horizontal,
-        filters: new Array(),
+        filters: {},
         hooks: {},
         interactions: {
             throttleDelayMouseMove: 50,
@@ -1062,14 +1062,6 @@ var Hermes = (function (exports) {
             ? [filter.value1, filter.value0]
             : [filter.value0, filter.value1];
     };
-    const internalToFilters = (filters) => {
-        return Object.keys(filters).reduce((acc, key) => {
-            acc[key] = filters[key]
-                .map(filter => internalToFilter(filter))
-                .sort((a, b) => comparePrimitive(a[0], b[0]));
-            return acc;
-        }, {});
-    };
     const isFilterEmpty = (filter) => {
         return isNaN(filter.p0) && isNaN(filter.p1);
     };
@@ -2040,7 +2032,7 @@ var Hermes = (function (exports) {
             _ixf.key = undefined;
             this.cleanUpFilters();
             // Make hook call back with all of the filter changes.
-            (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, internalToFilters(this.filters));
+            (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
         }
         cleanUpFilters() {
             Object.keys(this.filters).forEach(key => {

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -1381,12 +1381,16 @@ var Hermes = (function (exports) {
             const dataValidation = Hermes.validateData(data, this.dimensionsOriginal);
             if (!dataValidation.valid)
                 throw new HermesError(dataValidation.message);
+            console.log('known filters at set data');
+            console.log(this.filters);
             const filtered = removeInfinityNanSeries(data);
             this.data = filtered.data;
             this.dataCount = filtered.count;
             this.setDimensions(this.dimensionsOriginal, false);
             if (redraw)
                 this.redraw();
+            console.log('after redraw');
+            console.log(this.filters);
         }
         setDimensions(dimensions, redraw = true) {
             // Validate that the dimensions are set properly.

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -70,6 +70,7 @@ var Hermes = (function (exports) {
     const HERMES_CONFIG = {
         debug: false,
         direction: Direction.Horizontal,
+        filters: new Array(),
         hooks: {},
         interactions: {
             throttleDelayMouseMove: 50,
@@ -1303,6 +1304,7 @@ var Hermes = (function (exports) {
                     : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
                 mouseup: this.handleMouseUp.bind(this),
             };
+            if (this.config.filters) ;
             // Enable chart
             this.enable();
         }
@@ -2022,7 +2024,7 @@ var Hermes = (function (exports) {
                 // Make corresponding filter hook callback.
                 switch (_ixsa.type) {
                     case ActionType.FilterCreate:
-                        (_f = (_e = this.config.hooks).onFilterCreate) === null || _f === void 0 ? void 0 : _f.call(_e, internalToFilter(_ixf.active));
+                        (_f = (_e = this.config.hooks).onFilterCreate) === null || _f === void 0 ? void 0 : _f.call(_e, _ixf.active);
                         break;
                     case ActionType.FilterMove:
                         (_h = (_g = this.config.hooks).onFilterMove) === null || _h === void 0 ? void 0 : _h.call(_g, internalToFilter(_ixf.active));

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -1297,13 +1297,8 @@ var Hermes = (function (exports) {
                 mouseup: this.handleMouseUp.bind(this),
             };
             if (config === null || config === void 0 ? void 0 : config.filters) {
-                console.log('update filters from config');
                 Object.keys(this.config.filters).forEach((key) => {
-                    // Store active filter into filter list.
-                    this.filters[key] = [];
-                    this.config.filters[key].forEach(intf => {
-                        this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
-                    });
+                    this.filters[key] = this.config.filters[key];
                 });
             }
             // Enable chart
@@ -1374,13 +1369,8 @@ var Hermes = (function (exports) {
             // Set config early as setSize references it early.
             this.config = deepMerge(HERMES_CONFIG, config);
             if (config.filters) {
-                console.log('update filters from setConfig');
                 Object.keys(this.config.filters).forEach((key) => {
-                    // Store active filter into filter list.
-                    this.filters[key] = [];
-                    this.config.filters[key].forEach(intf => {
-                        this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
-                    });
+                    this.filters[key] = this.config.filters[key];
                 });
             }
             // Re-add observers as config impacts the throttling of the observer handlers.
@@ -1392,8 +1382,6 @@ var Hermes = (function (exports) {
             const dataValidation = Hermes.validateData(data, this.dimensionsOriginal);
             if (!dataValidation.valid)
                 throw new HermesError(dataValidation.message);
-            console.log('known filters at set data');
-            console.log(this.filters);
             const filtered = removeInfinityNanSeries(data);
             this.data = filtered.data;
             this.dataCount = filtered.count;
@@ -1784,10 +1772,6 @@ var Hermes = (function (exports) {
             for (let i = 0; i < _dl.length; i++) {
                 const key = this.dimensions[i].key;
                 const filters = this.filters[key] || [];
-                if (filters.length) {
-                    console.log('my column filters');
-                    console.log(filters);
-                }
                 const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
                 const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
                 const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||
@@ -1924,7 +1908,6 @@ var Hermes = (function (exports) {
         setActiveFilter(key, pos, value) {
             if (!this._)
                 return;
-            console.log('setActiveFilter');
             const _filters = this.filters;
             const _ix = this.ix;
             const _ixsa = _ix.shared.action;
@@ -1962,7 +1945,6 @@ var Hermes = (function (exports) {
             var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _m, _o;
             if (!this._)
                 return;
-            console.log('updateActiveFilter');
             const _dl = this._.dims.list;
             const _dsa = this._.dims.shared.axes;
             const _ix = this.ix;
@@ -2057,12 +2039,11 @@ var Hermes = (function (exports) {
             // Overwrite active filter to remove reference to filter in filters list.
             _ixf.active = { ...FILTER };
             _ixf.key = undefined;
-            // this.cleanUpFilters();
+            this.cleanUpFilters();
             // Make hook call back with all of the filter changes.
             (_o = (_m = this.config.hooks) === null || _m === void 0 ? void 0 : _m.onFilterChange) === null || _o === void 0 ? void 0 : _o.call(_m, this.filters);
         }
         cleanUpFilters() {
-            console.log('cleanUpFilters');
             Object.keys(this.filters).forEach(key => {
                 const filters = this.filters[key] || [];
                 for (let i = 0; i < filters.length; i++) {

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -1297,19 +1297,12 @@ var Hermes = (function (exports) {
                 mouseup: this.handleMouseUp.bind(this),
             };
             if (config === null || config === void 0 ? void 0 : config.filters) {
-                // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
-                // setActiveFilter
-                console.log(this.config.filters);
                 Object.keys(this.config.filters).forEach((key) => {
-                    // const addFilter = this.config.filters[key];
-                    // this.setActiveFilter(key, addFilter., addFilter.range);
                     // Store active filter into filter list.
-                    console.log(key);
                     this.filters[key] = [];
                     this.config.filters[key].forEach(intf => {
                         this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
                     });
-                    // _ixsa.filterIndex = _filters[key].length - 1;
                 });
             }
             // Enable chart
@@ -1429,6 +1422,14 @@ var Hermes = (function (exports) {
                 }
                 return internal;
             });
+            if (redraw)
+                this.redraw();
+        }
+        setFilters(filters, redraw = false) {
+            console.log(this.filters);
+            console.log('changed to');
+            console.log(filters);
+            this.filters = filters;
             if (redraw)
                 this.redraw();
         }
@@ -1919,14 +1920,9 @@ var Hermes = (function (exports) {
             const _ixsa = _ix.shared.action;
             const _ixf = _ix.filters;
             const _dsa = this._.dims.shared.axes;
-            console.log('this.ix action');
-            console.log(_ixsa);
             // See if there is an existing matching filter based on % position.
-            console.log('at filter time');
-            console.log(_filters);
             const index = (_filters[key] || []).findIndex(filter => pos >= filter.p0 && pos <= filter.p1);
             if (index !== -1) {
-                console.log('index not -1');
                 _ixf.active = _filters[key][index];
                 _ixf.active.startP0 = _ixf.active.p0;
                 _ixf.active.startP1 = _ixf.active.p1;
@@ -1944,7 +1940,6 @@ var Hermes = (function (exports) {
                 }
             }
             else {
-                console.log('index is -1');
                 _ixsa.type = ActionType.FilterCreate;
                 _ixf.active = { p0: pos, p1: pos, value0: value, value1: value };
                 // Store active filter into filter list.

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -1296,7 +1296,7 @@ var Hermes = (function (exports) {
                     : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
                 mouseup: this.handleMouseUp.bind(this),
             };
-            if (this.config.filters) {
+            if (config === null || config === void 0 ? void 0 : config.filters) {
                 // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
                 // setActiveFilter
                 console.log(this.config.filters);

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -1296,7 +1296,13 @@ var Hermes = (function (exports) {
                     : throttle((e) => this.handleMouseMove.bind(this)(e), this.config.interactions.throttleDelayMouseMove),
                 mouseup: this.handleMouseUp.bind(this),
             };
-            if (this.config.filters) ;
+            if (this.config.filters) {
+                // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
+                // setActiveFilter
+                Object.keys(this.config.filters).forEach((key) => {
+                    this.filters[key] = this.config.filters[key];
+                });
+            }
             // Enable chart
             this.enable();
         }

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -1299,8 +1299,17 @@ var Hermes = (function (exports) {
             if (this.config.filters) {
                 // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
                 // setActiveFilter
+                console.log(this.config.filters);
                 Object.keys(this.config.filters).forEach((key) => {
-                    this.filters[key] = this.config.filters[key];
+                    // const addFilter = this.config.filters[key];
+                    // this.setActiveFilter(key, addFilter., addFilter.range);
+                    // Store active filter into filter list.
+                    console.log(key);
+                    this.filters[key] = [];
+                    this.config.filters[key].forEach(intf => {
+                        this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
+                    });
+                    // _ixsa.filterIndex = _filters[key].length - 1;
                 });
             }
             // Enable chart

--- a/dist/hermes.iife.js
+++ b/dist/hermes.iife.js
@@ -1373,6 +1373,16 @@ var Hermes = (function (exports) {
         setConfig(config = {}, redraw = true) {
             // Set config early as setSize references it early.
             this.config = deepMerge(HERMES_CONFIG, config);
+            if (config.filters) {
+                console.log('update filters from setConfig');
+                Object.keys(this.config.filters).forEach((key) => {
+                    // Store active filter into filter list.
+                    this.filters[key] = [];
+                    this.config.filters[key].forEach(intf => {
+                        this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
+                    });
+                });
+            }
             // Re-add observers as config impacts the throttling of the observer handlers.
             this.addObservers();
             if (redraw)
@@ -1774,8 +1784,10 @@ var Hermes = (function (exports) {
             for (let i = 0; i < _dl.length; i++) {
                 const key = this.dimensions[i].key;
                 const filters = this.filters[key] || [];
-                console.log('my column filters');
-                console.log(filters);
+                if (filters.length) {
+                    console.log('my column filters');
+                    console.log(filters);
+                }
                 const isDimActive = _ixsa.type === ActionType.LabelMove && _ixsa.dimIndex === i;
                 const isDimFocused = (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.type) === FocusType.DimensionLabel && (_ixsf === null || _ixsf === void 0 ? void 0 : _ixsf.dimIndex) === i;
                 const isAxisActive = (_ixsa.type === ActionType.FilterCreate ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "hermes-parallel-coordinates",
-  "version": "0.5.18",
+  "name": "@determined-ai/hermes-parallel-coordinates",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "hermes-parallel-coordinates",
-      "version": "0.5.18",
+      "name": "@determined-ai/hermes-parallel-coordinates",
+      "version": "0.6.1",
       "license": "ISC",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "hermes-parallel-coordinates",
-      "version": "0.5.17",
+      "version": "0.5.18",
       "license": "ISC",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.1",
@@ -1396,6 +1396,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
@@ -1405,6 +1419,25 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
@@ -1412,9 +1445,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -8635,13 +8668,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
-      "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
         "source-map-support": "~0.5.20"
       },
       "bin": {
@@ -8649,14 +8683,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "peerDependencies": {
-        "acorn": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "acorn": {
-          "optional": true
-        }
       }
     },
     "node_modules/test-exclude": {
@@ -10340,11 +10366,38 @@
         }
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
     "@jridgewell/resolve-uri": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
       "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
       "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.11",
@@ -10353,9 +10406,9 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -15843,13 +15896,14 @@
       }
     },
     "terser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
-      "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
         "source-map-support": "~0.5.20"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "hermes-parallel-coordinates",
-  "version": "0.5.18",
+  "name": "@determined-ai/hermes-parallel-coordinates",
+  "version": "0.6.1",
   "description": "A lightweight and fast canvas-based parallel coordinates chart library.",
   "keywords": [
     "es6",

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -37,6 +37,7 @@ export const TRUNCATE_SUFFIX = '...';
 export const HERMES_CONFIG: t.Config = {
   debug: false,
   direction: t.Direction.Horizontal,
+  filters: new Array<t.InternalFilter>(),
   hooks: {},
   interactions: {
     throttleDelayMouseMove: 50,

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -37,7 +37,7 @@ export const TRUNCATE_SUFFIX = '...';
 export const HERMES_CONFIG: t.Config = {
   debug: false,
   direction: t.Direction.Horizontal,
-  filters: new Array<t.InternalFilter>(),
+  filters: {},
   hooks: {},
   interactions: {
     throttleDelayMouseMove: 50,

--- a/src/index.ts
+++ b/src/index.ts
@@ -805,9 +805,15 @@ class Hermes {
     const _ixf = _ix.filters;
     const _dsa = this._.dims.shared.axes;
 
+    console.log('this.ix action')
+    console.log(_ixsa);
+
     // See if there is an existing matching filter based on % position.
+    console.log('at filter time')
+    console.log(_filters);
     const index = (_filters[key] || []).findIndex(filter => pos >= filter.p0 && pos <= filter.p1);
     if (index !== -1) {
+      console.log('index not -1');
       _ixf.active = _filters[key][index];
       _ixf.active.startP0 = _ixf.active.p0;
       _ixf.active.startP1 = _ixf.active.p1;
@@ -827,6 +833,7 @@ class Hermes {
         _ixsa.type = t.ActionType.FilterMove;
       }
     } else {
+      console.log('index is -1')
       _ixsa.type = t.ActionType.FilterCreate;
       _ixf.active = { p0: pos, p1: pos, value0: value, value1: value };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import * as tester from './utils/tester';
 
 export {
   ActionType, DimensionLayout, DimensionType,
-  Direction, FocusType, LabelPlacement, PathType,
+  Direction, FocusType, InternalFilter, InternalFilters, LabelPlacement, PathType,
 } from './types';
 
 class Hermes {
@@ -85,6 +85,7 @@ class Hermes {
 
     if (this.config.filters) {
       // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
+      // setActiveFilter
     }
 
     // Enable chart
@@ -931,7 +932,7 @@ class Hermes {
     this.cleanUpFilters();
 
     // Make hook call back with all of the filter changes.
-    this.config.hooks?.onFilterChange?.(ix.internalToFilters(this.filters));
+    this.config.hooks?.onFilterChange?.(this.filters);
   }
 
   protected cleanUpFilters(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,13 +84,8 @@ class Hermes {
     };
 
     if (config?.filters) {
-      console.log('update filters from config')
       Object.keys(this.config.filters).forEach((key) => {
-        // Store active filter into filter list.
-        this.filters[key] = [];
-        this.config.filters[key].forEach(intf => {
-          this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
-        });
+        this.filters[key] = this.config.filters[key];
       });
     }
 
@@ -169,13 +164,8 @@ class Hermes {
     this.config = deepMerge(DEFAULT.HERMES_CONFIG, config) as t.Config;
 
     if (config.filters) {
-      console.log('update filters from setConfig')
       Object.keys(this.config.filters).forEach((key) => {
-        // Store active filter into filter list.
-        this.filters[key] = [];
-        this.config.filters[key].forEach(intf => {
-          this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
-        });
+        this.filters[key] = this.config.filters[key];
       });
     }
 
@@ -189,8 +179,6 @@ class Hermes {
     const dataValidation = Hermes.validateData(data, this.dimensionsOriginal);
     if (!dataValidation.valid) throw new HermesError(dataValidation.message);
 
-    console.log('known filters at set data');
-    console.log(this.filters);
     const filtered = removeInfinityNanSeries(data);
     this.data = filtered.data;
     this.dataCount = filtered.count;
@@ -643,10 +631,6 @@ class Hermes {
     for (let i = 0; i < _dl.length; i++) {
       const key = this.dimensions[i].key;
       const filters = this.filters[key] || [];
-      if (filters.length) {
-        console.log('my column filters');
-        console.log(filters);
-      }
       const isDimActive = _ixsa.type === t.ActionType.LabelMove && _ixsa.dimIndex === i;
       const isDimFocused = _ixsf?.type === t.FocusType.DimensionLabel && _ixsf?.dimIndex === i;
       const isAxisActive = (
@@ -809,7 +793,6 @@ class Hermes {
   protected setActiveFilter(key: string, pos: number, value: t.Primitive): void {
     if (!this._) return;
 
-    console.log('setActiveFilter');
     const _filters = this.filters;
     const _ix = this.ix;
     const _ixsa = _ix.shared.action;
@@ -850,8 +833,6 @@ class Hermes {
 
   protected updateActiveFilter(e: MouseEvent): void {
     if (!this._) return;
-
-    console.log('updateActiveFilter');
 
     const _dl = this._.dims.list;
     const _dsa = this._.dims.shared.axes;
@@ -955,14 +936,13 @@ class Hermes {
     _ixf.active = { ...DEFAULT.FILTER };
     _ixf.key = undefined;
 
-    // this.cleanUpFilters();
+    this.cleanUpFilters();
 
     // Make hook call back with all of the filter changes.
     this.config.hooks?.onFilterChange?.(this.filters);
   }
 
   protected cleanUpFilters(): void {
-    console.log('cleanUpFilters');
     Object.keys(this.filters).forEach(key => {
       const filters = this.filters[key] || [];
       for (let i = 0; i < filters.length; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,8 +86,18 @@ class Hermes {
     if (this.config.filters) {
       // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
       // setActiveFilter
+      console.log(this.config.filters);
       Object.keys(this.config.filters).forEach((key) => {
-        this.filters[key] = this.config.filters[key];
+        // const addFilter = this.config.filters[key];
+        // this.setActiveFilter(key, addFilter., addFilter.range);
+
+        // Store active filter into filter list.
+        console.log(key);
+        this.filters[key] = [];
+        this.config.filters[key].forEach(intf => {
+          this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
+        });
+        // _ixsa.filterIndex = _filters[key].length - 1;
       });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,20 +84,12 @@ class Hermes {
     };
 
     if (config?.filters) {
-      // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
-      // setActiveFilter
-      console.log(this.config.filters);
       Object.keys(this.config.filters).forEach((key) => {
-        // const addFilter = this.config.filters[key];
-        // this.setActiveFilter(key, addFilter., addFilter.range);
-
         // Store active filter into filter list.
-        console.log(key);
         this.filters[key] = [];
         this.config.filters[key].forEach(intf => {
           this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
         });
-        // _ixsa.filterIndex = _filters[key].length - 1;
       });
     }
 
@@ -250,6 +242,14 @@ class Hermes {
       return internal;
     });
 
+    if (redraw) this.redraw();
+  }
+
+  public setFilters(filters: t.InternalFilters, redraw = false): void {
+    console.log(this.filters);
+    console.log('changed to');
+    console.log(filters);
+    this.filters = filters;
     if (redraw) this.redraw();
   }
 
@@ -805,15 +805,9 @@ class Hermes {
     const _ixf = _ix.filters;
     const _dsa = this._.dims.shared.axes;
 
-    console.log('this.ix action')
-    console.log(_ixsa);
-
     // See if there is an existing matching filter based on % position.
-    console.log('at filter time')
-    console.log(_filters);
     const index = (_filters[key] || []).findIndex(filter => pos >= filter.p0 && pos <= filter.p1);
     if (index !== -1) {
-      console.log('index not -1');
       _ixf.active = _filters[key][index];
       _ixf.active.startP0 = _ixf.active.p0;
       _ixf.active.startP1 = _ixf.active.p1;
@@ -833,7 +827,6 @@ class Hermes {
         _ixsa.type = t.ActionType.FilterMove;
       }
     } else {
-      console.log('index is -1')
       _ixsa.type = t.ActionType.FilterCreate;
       _ixf.active = { p0: pos, p1: pos, value0: value, value1: value };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,12 +177,17 @@ class Hermes {
     const dataValidation = Hermes.validateData(data, this.dimensionsOriginal);
     if (!dataValidation.valid) throw new HermesError(dataValidation.message);
 
+    console.log('known filters at set data');
+    console.log(this.filters);
     const filtered = removeInfinityNanSeries(data);
     this.data = filtered.data;
     this.dataCount = filtered.count;
     this.setDimensions(this.dimensionsOriginal, false);
 
     if (redraw) this.redraw();
+
+    console.log('after redraw');
+    console.log(this.filters);
   }
 
   public setDimensions(dimensions: t.Dimension[], redraw = true): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,17 @@ class Hermes {
     // Set config early as setSize references it early.
     this.config = deepMerge(DEFAULT.HERMES_CONFIG, config) as t.Config;
 
+    if (config.filters) {
+      console.log('update filters from setConfig')
+      Object.keys(this.config.filters).forEach((key) => {
+        // Store active filter into filter list.
+        this.filters[key] = [];
+        this.config.filters[key].forEach(intf => {
+          this.filters[key].push({ p0: intf.p0, p1: intf.p1, value0: intf.value0, value1: intf.value1 });
+        });
+      });
+    }
+
     // Re-add observers as config impacts the throttling of the observer handlers.
     this.addObservers();
 
@@ -632,8 +643,10 @@ class Hermes {
     for (let i = 0; i < _dl.length; i++) {
       const key = this.dimensions[i].key;
       const filters = this.filters[key] || [];
-      console.log('my column filters');
-      console.log(filters);
+      if (filters.length) {
+        console.log('my column filters');
+        console.log(filters);
+      }
       const isDimActive = _ixsa.type === t.ActionType.LabelMove && _ixsa.dimIndex === i;
       const isDimFocused = _ixsf?.type === t.FocusType.DimensionLabel && _ixsf?.dimIndex === i;
       const isAxisActive = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -912,7 +912,7 @@ class Hermes {
       // Make corresponding filter hook callback.
       switch (_ixsa.type) {
         case t.ActionType.FilterCreate:
-          this.config.hooks.onFilterCreate?.(ix.internalToFilter(_ixf.active));
+          this.config.hooks.onFilterCreate?.(_ixf.active);
           break;
         case t.ActionType.FilterMove:
           this.config.hooks.onFilterMove?.(ix.internalToFilter(_ixf.active));

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,10 @@ class Hermes {
       mouseup: this.handleMouseUp.bind(this),
     };
 
+    if (this.config.filters) {
+      // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
+    }
+
     // Enable chart
     this.enable();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ class Hermes {
       mouseup: this.handleMouseUp.bind(this),
     };
 
-    if (this.config.filters) {
+    if (config?.filters) {
       // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
       // setActiveFilter
       console.log(this.config.filters);

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ class Hermes {
     };
 
     if (config?.filters) {
+      console.log('update filters from config')
       Object.keys(this.config.filters).forEach((key) => {
         // Store active filter into filter list.
         this.filters[key] = [];
@@ -185,9 +186,6 @@ class Hermes {
     this.setDimensions(this.dimensionsOriginal, false);
 
     if (redraw) this.redraw();
-
-    console.log('after redraw');
-    console.log(this.filters);
   }
 
   public setDimensions(dimensions: t.Dimension[], redraw = true): void {
@@ -247,14 +245,6 @@ class Hermes {
       return internal;
     });
 
-    if (redraw) this.redraw();
-  }
-
-  public setFilters(filters: t.InternalFilters, redraw = false): void {
-    console.log(this.filters);
-    console.log('changed to');
-    console.log(filters);
-    this.filters = filters;
     if (redraw) this.redraw();
   }
 
@@ -642,6 +632,8 @@ class Hermes {
     for (let i = 0; i < _dl.length; i++) {
       const key = this.dimensions[i].key;
       const filters = this.filters[key] || [];
+      console.log('my column filters');
+      console.log(filters);
       const isDimActive = _ixsa.type === t.ActionType.LabelMove && _ixsa.dimIndex === i;
       const isDimFocused = _ixsf?.type === t.FocusType.DimensionLabel && _ixsf?.dimIndex === i;
       const isAxisActive = (
@@ -804,6 +796,7 @@ class Hermes {
   protected setActiveFilter(key: string, pos: number, value: t.Primitive): void {
     if (!this._) return;
 
+    console.log('setActiveFilter');
     const _filters = this.filters;
     const _ix = this.ix;
     const _ixsa = _ix.shared.action;
@@ -844,6 +837,8 @@ class Hermes {
 
   protected updateActiveFilter(e: MouseEvent): void {
     if (!this._) return;
+
+    console.log('updateActiveFilter');
 
     const _dl = this._.dims.list;
     const _dsa = this._.dims.shared.axes;
@@ -947,13 +942,14 @@ class Hermes {
     _ixf.active = { ...DEFAULT.FILTER };
     _ixf.key = undefined;
 
-    this.cleanUpFilters();
+    // this.cleanUpFilters();
 
     // Make hook call back with all of the filter changes.
     this.config.hooks?.onFilterChange?.(this.filters);
   }
 
   protected cleanUpFilters(): void {
+    console.log('cleanUpFilters');
     Object.keys(this.filters).forEach(key => {
       const filters = this.filters[key] || [];
       for (let i = 0; i < filters.length; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,9 @@ class Hermes {
     if (this.config.filters) {
       // protected setActiveFilter(key: string, pos: number, value: t.Primitive)
       // setActiveFilter
+      Object.keys(this.config.filters).forEach((key) => {
+        this.filters[key] = this.config.filters[key];
+      });
     }
 
     // Enable chart

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,7 +208,7 @@ export interface Config {
   hooks: {
     onDimensionMove?: (dimension: Dimension, newIndex: number, oldIndex: number) => void;
     onFilterChange?: (filters: Filters) => void;
-    onFilterCreate?: (filter: Filter) => void,
+    onFilterCreate?: (filter: InternalFilter) => void,
     onFilterMove?: (filter: Filter) => void,
     onFilterRemove?: (filter: Filter) => void,
     onFilterResize?: (filter: Filter) => void,

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,6 +204,7 @@ export type ActualAndFiniteRanges = { actual: Range; finite: Range }
 export interface Config {
   debug: boolean;
   direction: EDirection;
+  filters: InternalFilter[];
   hooks: {
     onDimensionMove?: (dimension: Dimension, newIndex: number, oldIndex: number) => void;
     onFilterChange?: (filters: Filters) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,10 +204,10 @@ export type ActualAndFiniteRanges = { actual: Range; finite: Range }
 export interface Config {
   debug: boolean;
   direction: EDirection;
-  filters: InternalFilter[];
+  filters: InternalFilters;
   hooks: {
     onDimensionMove?: (dimension: Dimension, newIndex: number, oldIndex: number) => void;
-    onFilterChange?: (filters: Filters) => void;
+    onFilterChange?: (filters: InternalFilters) => void;
     onFilterCreate?: (filter: InternalFilter) => void,
     onFilterMove?: (filter: Filter) => void,
     onFilterRemove?: (filter: Filter) => void,


### PR DESCRIPTION
For @trentwatt to review:

In our app, changes to update the data redraw the element and clear any existing filters.

For consistency, we'd like to receive the internal format filters (`InternalFilters` dictionary with format `{ columnName: [filters] }`) from the onFilterChange events and pass those `InternalFilters` objects back into the object through the config.