### PR TITLE
feat: series style [Issue-116]

### DIFF
--- a/dist/hermes.d.ts
+++ b/dist/hermes.d.ts
@@ -170,6 +170,7 @@ declare namespace Hermes {
     overrideNegativeInfinity?: StyleLine;
     overridePositiveInfinity?: StyleLine;
     path: PathOptions;
+    series?: StyleLine[];
     targetColorScale?: string[];
     targetDimensionKey?: DimensionKey;
   }

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -125,6 +125,7 @@ export const HERMES_CONFIG: t.Config = {
         options: {},
         type: t.PathType.Straight,
       },
+      series: [],
     },
     dimension: {
       label: {

--- a/src/index.config.test.ts
+++ b/src/index.config.test.ts
@@ -170,7 +170,7 @@ describe('Hermes Config', () => {
         });
       });
 
-      describe('NaN, -Inf, and +Inf', () => {
+      describe('override NaN, -Inf, and +Inf styles', () => {
         it('should render unique colors for NaN, -Inf, and +Inf', () => {
           testSetConfig(setup, {
             direction: t.Direction.Horizontal,
@@ -179,6 +179,27 @@ describe('Hermes Config', () => {
                 overrideNaN: { lineWidth: 2, strokeStyle: 'rgba(255, 0, 0, 0.3)' },
                 overrideNegativeInfinity: { lineWidth: 2, strokeStyle: 'rgba(0, 255, 0, 0.3)' },
                 overridePositiveInfinity: { lineWidth: 2, strokeStyle: 'rgba(0, 0, 255, 0.3)' },
+              },
+            },
+          });
+          expect(setup.hermes.getCtx().__getDrawCalls()).toMatchSnapshot();
+        });
+      });
+
+      describe('override series style', () => {
+        it('should render unique colors defined by a series array of styles', () => {
+          testSetConfig(setup, {
+            direction: t.Direction.Horizontal,
+            style: {
+              data: {
+                series: [
+                  undefined,
+                  { lineWidth: 2, strokeStyle: 'rgba(255, 0, 0, 0.3)' },
+                  undefined,
+                  { lineWidth: 2, strokeStyle: 'rgba(0, 255, 0, 0.3)' },
+                  undefined,
+                  { lineWidth: 2, strokeStyle: 'rgba(0, 0, 255, 0.3)' },
+                ],
               },
             },
           });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1144,6 +1144,8 @@ class Hermes {
       let hasPositiveInfinity = false;
       let isFilteredOut = false;
 
+      if (dataStyle.series?.[k]) dataDefaultStyle = dataStyle.series?.[k];
+
       const series = this.dimensions.map((dimension, i) => {
         const key = dimension.key;
         const layout = _dl[i].layout;

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,6 +125,7 @@ export interface DataOptions {
   overrideNegativeInfinity?: StyleLine;
   overridePositiveInfinity?: StyleLine;
   path: PathOptions;
+  series?: StyleLine[];
   targetColorScale?: string[];
   targetDimensionKey?: DimensionKey;
 }


### PR DESCRIPTION
Add support for overriding individual data series with a specific line style.

NOTE: out-of-filter-range (grey typically), NaN, -Inf, and +Inf styles will still supersede the series colors. This is the same behavior for the default series color.

Sample config for a chart that is rendering 10 lines.
```
const config = { 
  style: {
    data: {
      series: [
        undefined,
        { lineWidth: 2, strokeStyle: 'rgba(255, 0, 0, 1.0)' },
        undefined,
        { lineWidth: 2, strokeStyle: 'rgba(0, 255, 0, 1.0)' },
        undefined,
        { lineWidth: 2, strokeStyle: 'rgba(255, 150, 0, 1.0)' },
      ],
    },
  },
};
```

![Screen Shot 2023-05-11 at 10 33 29 AM](https://github.com/hkang1/hermes/assets/220971/eac8966b-44fa-4456-a9c7-9f7f40052771)
