### PR TITLE
chore: re-export types for library use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import { distance, isPointInTriangle } from './utils/math';
 import { truncate } from './utils/string';
 import * as tester from './utils/tester';
 
+export * from './types';
+
 class Hermes {
   protected element: HTMLElement;
   protected canvas: HTMLCanvasElement;


### PR DESCRIPTION
Currently dictionary/object types like `DimensionType` are not importable or defined.