### PR TITLE
feat: handle functions for obj2str and str2obj conversions

### DIFF
--- a/src/utils/data.test.ts
+++ b/src/utils/data.test.ts
@@ -369,6 +369,17 @@ describe('data utilities', () => {
   Number.Infinity,
   -Number.Infinity
 ]`;
+    const objFn = {
+      arrow: ({ x, y }: { x: number, y: number }) => x + y,
+      normal: function add(x: number, y: number) {
+        return x + y;
+      },
+    };
+    const objFnString = `{
+  "arrow": "({ x, y }) => x + y",
+  "normal": "function add(x, y) {\\n                return x + y;\\n            }"
+}`;
+
     it('should convert object to strings', () => {
       expect(utils.obj2str(obj, false)).toBe(objStr);
     });
@@ -399,6 +410,19 @@ describe('data utilities', () => {
 
     it('should convert string to array and handle special +/-Inf and NaN', () => {
       expect(utils.str2obj(arrStrSpecial)).toMatchObject(arr);
+    });
+
+    it('should convert object of functions to strings', () => {
+      expect(utils.obj2str(objFn)).toBe(objFnString);
+    });
+
+    it('should convert string to object of functions', () => {
+      const obj = utils.str2obj<{
+        arrow: ({ x, y }: { x: number, y: number }) => number,
+        normal: (x: number, y: number) => number,
+      }>(objFnString);
+      expect(obj.arrow({ x: 1, y: 2 })).toBe(3);
+      expect(obj.normal(2, 3)).toBe(5);
     });
   });
 

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -200,6 +200,8 @@ export const obj2str = <T extends NestedObject | Array<unknown>>(obj: T, infNaN 
         if (value === Infinity) return 'Number.Infinity';
         if (value === -Infinity) return '-Number.Infinity';
       }
+    } else if (typeof value === 'function') {
+      return `${value}`;
     }
     return value;
   }
@@ -213,6 +215,10 @@ export const str2obj = <T extends NestedObject | Array<unknown>>(str: string, in
       if (/^-(Number\.)?Infinity$/.test(value)) return -Infinity;
       if (/^(Number\.)?Infinity$/.test(value)) return Infinity;
       if (/^(Number\.)?NaN$/.test(value)) return NaN;
+      if (/^\s*function/gm.test(value) ||
+          /^\s*\(?\s*{?\s*[\w$]*\s*(,\s*[\w$]*\s*)*}?\s*\)?\s*=>/gm.test(value)) {
+        return eval('(' + value + ')');
+      }
     }
     return value;
   }


### PR DESCRIPTION
extend JSON.parse and JSON.stringify modification to also handle function values (including arrow functions) on top of handling +/-Infinity and NaN values.