### PR TITLE
chore: warn instead of throwing error for 0px sized container

### DIFF
--- a/src/index.core.test.ts
+++ b/src/index.core.test.ts
@@ -77,22 +77,21 @@ describe('Hermes Core', () => {
       const originalBoundingClientRect = Element.prototype.getBoundingClientRect;
       Element.prototype.getBoundingClientRect = getBoundingClientRect(boundingRect);
 
-      let hermes: utils.HermesTester | undefined;
-      let error: HermesError | undefined;
+      const consoleWarn = console.warn;
 
-      try {
-        hermes = new utils.HermesTester(`#${elementId}`, utils.DEFAULT_DIMENSIONS);
-      } catch (e) {
-        error = e as HermesError;
-      }
+      console.warn = jest.fn();
 
-      expect(error?.message).toMatch(/width and height must both be greater than 0/i);
-      expect(hermes).toBeUndefined();
+      const hermes = new utils.HermesTester(`#${elementId}`, utils.DEFAULT_DIMENSIONS);
+
+      expect(console.warn).toHaveBeenCalledWith('Target element width and height must both be greater than 0px.');
+      expect(hermes).toBeDefined();
 
       hermes?.destroy();
       document.body.removeChild(element);
 
       Element.prototype.getBoundingClientRect = originalBoundingClientRect;
+
+      console.warn = consoleWarn;
     });
 
     it('should use existing canvas in element', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ class Hermes {
 
     const rect = this.element.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) {
-      throw new HermesError('Target element width and height must both be greater than 0px.');
+      console.warn('Target element width and height must both be greater than 0px.');
     }
 
     // Create a canvas and append it to the target element. Only if there isn't an existing one.


### PR DESCRIPTION
Instead of throwing an error, simply warn in the console about 0px sized container.